### PR TITLE
Colorize word pairs

### DIFF
--- a/Higurashi no Naku Koro ni/Season 01/(Hi10)_Higurashi_no_Naku_Koro_ni_-_01_(DVD_480p)_(Exiled-Destiny).ja-en.ass
+++ b/Higurashi no Naku Koro ni/Season 01/(Hi10)_Higurashi_no_Naku_Koro_ni_-_01_(DVD_480p)_(Exiled-Destiny).ja-en.ass
@@ -13,11 +13,11 @@ Style: Default-ja,Arial,28.0,&H00FFFFFF,&H00FF0000,&H00000000,&H00000000,-1,0,0,
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
-Dialogue: 0,0:00:01.50,0:00:04.93,Default,,0,0,0,,June 1983
-Dialogue: 0,0:00:12.64,0:00:15.34,Default-ja,,0,0,0,,（殴る音）\Nハァ… ハァ…
+Dialogue: 0,0:00:01.50,0:00:04.93,Default,,0,0,0,,{\c&HFFFFFF&}June{\c&HFFFFFF&} {\c&HCCFFFF&}1983{\c&HCCFFFF&}
+Dialogue: 0,0:00:12.64,0:00:15.34,Default-ja,,0,0,0,,{\c&HFFFFFF&}（{\c&HFFFFFF&}{\c&HCCFFFF&}殴る{\c&HCCFFFF&}音）\Nハァ…ハァ…
 Dialogue: 0,0:00:24.25,0:00:26.15,Default-ja,,0,0,0,,ハァ…
-Dialogue: 0,0:00:26.26,0:00:28.92,Default-ja,,0,0,0,,ハァ… ハァ…
-Dialogue: 0,0:00:28.99,0:00:33.95,Default,,0,0,0,,Spirited Away by the Demon\NChapter One, The Beginning
+Dialogue: 0,0:00:26.26,0:00:28.92,Default-ja,,0,0,0,,{\c&HCCFFCC&}ハァ{\c&HCCFFCC&}{\c&HFFFFCC&}…{\c&HFFFFCC&}{\c&HFFCCCC&}ハァ{\c&HFFCCCC&}{\c&HFFCCFF&}…{\c&HFFCCFF&}
+Dialogue: 0,0:00:28.99,0:00:33.95,Default,,0,0,0,,{\c&HCCFFCC&}Spirited{\c&HCCFFCC&} {\c&HFFFFCC&}Away{\c&HFFFFCC&} {\c&HFFCCCC&}by{\c&HFFCCCC&} {\c&HFFCCFF&}the{\c&HFFCCFF&} Demon \ NChapter One , The Beginning
 Dialogue: 0,0:00:47.71,0:00:54.81,Default,,0,0,0,,When They Cry
 Dialogue: 0,0:01:06.39,0:01:14.43,Default,,0,0,0,,Behind where I looked back\N(who's there in the front)?
 Dialogue: 0,0:01:15.44,0:01:23.18,Default,,0,0,0,,I raised my nails in the dark\N(and slashed the night).
@@ -26,665 +26,665 @@ Dialogue: 0,0:01:32.79,0:01:42.53,Default,,0,0,0,,If you don't have\Na place to 
 Dialogue: 0,0:01:42.86,0:01:47.23,Default,,0,0,0,,...then stop here on my finger.
 Dialogue: 0,0:01:47.34,0:01:51.97,Default,,0,0,0,,I'll take you away\Nalong with that finger.
 Dialogue: 0,0:01:52.07,0:01:56.48,Default,,0,0,0,,To the unopenable\Nforest where cicadas cry.
-Dialogue: 0,0:01:56.58,0:02:03.64,Default,,0,0,0,,You can't turn back anymore.
-Dialogue: 0,0:02:07.89,0:02:11.03,Default-ja,,0,0,0,,（圭一(けいいち)）ウ… ウ～ン…
-Dialogue: 0,0:02:15.36,0:02:16.70,Default-ja,,0,0,0,,ウ～ン…
-Dialogue: 0,0:02:19.23,0:02:20.43,Default,,0,0,0,,Good morning.
-Dialogue: 0,0:02:19.27,0:02:21.47,Default-ja,,0,0,0,,（圭一）おはよう\N（藍子(あいこ)）おはよう
-Dialogue: 0,0:02:20.54,0:02:22.20,Default,,0,0,0,,Good morning.
-Dialogue: 0,0:02:22.30,0:02:23.33,Default,,0,0,0,,I'm going.
-Dialogue: 0,0:02:22.34,0:02:23.44,Default-ja,,0,0,0,,（圭一）いってきま～す
-Dialogue: 0,0:02:23.64,0:02:25.30,Default,,0,0,0,,Oh, Keiichi.
-Dialogue: 0,0:02:23.64,0:02:24.61,Default-ja,,0,0,0,,（藍子）ああ 圭一
-Dialogue: 0,0:02:25.41,0:02:28.27,Default,,0,0,0,,Thank Rena-chan for the pickles.
-Dialogue: 0,0:02:25.44,0:02:28.28,Default-ja,,0,0,0,,（藍子）レナちゃんに“お漬物\Nありがとう”って伝えてね
-Dialogue: 0,0:02:28.38,0:02:29.34,Default,,0,0,0,,Okay.
-Dialogue: 0,0:02:28.38,0:02:29.51,Default-ja,,0,0,0,,あいよ！
-Dialogue: 0,0:02:32.21,0:02:36.15,Default,,0,0,0,,It's been one month since\NI moved to Hinamizawa.
-Dialogue: 0,0:02:32.31,0:02:35.32,Default-ja,,0,0,0,,（圭一）\Nこの雛見沢(ひなみざわ)に引っ越して １か月
-Dialogue: 0,0:02:36.25,0:02:40.24,Default,,0,0,0,,For the first time,\NI learned that air can smell good.
-Dialogue: 0,0:02:36.32,0:02:39.89,Default-ja,,0,0,0,,空気にも味があることを\N俺は初めて知った
-Dialogue: 0,0:02:40.36,0:02:41.82,Default,,0,0,0,,Keiichi-kun!
-Dialogue: 0,0:02:40.39,0:02:43.63,Default-ja,,0,0,0,,（ﾚﾅ）圭一君 おっはよう！
-Dialogue: 0,0:02:42.06,0:02:43.55,Default,,0,0,0,,Good morning!
-Dialogue: 0,0:02:43.96,0:02:45.96,Default-ja,,0,0,0,,（圭一）相変わらず早(はえ)えな
+Dialogue: 0,0:01:56.58,0:02:03.64,Default,,0,0,0,,{\c&HCCE5FF&}You{\c&HCCE5FF&} {\c&HFFD8B1&}can't{\c&HFFD8B1&} {\c&HCCE0FF&}turn{\c&HCCE0FF&} {\c&HFFFFE0&}back{\c&HFFFFE0&} {\c&HFFF0F5&}anymore{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
+Dialogue: 0,0:02:07.89,0:02:11.03,Default-ja,,0,0,0,,{\c&HCCE5FF&}（{\c&HCCE5FF&}{\c&HFFD8B1&}圭一{\c&HFFD8B1&}{\c&HCCE0FF&}({\c&HCCE0FF&}{\c&HFFFFE0&}けい{\c&HFFFFE0&}{\c&HFFF0F5&}いち{\c&HFFF0F5&}{\c&HFFE4E1&})）{\c&HFFE4E1&}ウ…ウ～ン…
+Dialogue: 0,0:02:15.36,0:02:16.70,Default-ja,,0,0,0,,{\c&HFAFAD2&}ウ{\c&HFAFAD2&}{\c&HFFFACD&}～{\c&HFFFACD&}{\c&HFFEFD5&}ン{\c&HFFEFD5&}…
+Dialogue: 0,0:02:19.23,0:02:20.43,Default,,0,0,0,,{\c&HFAFAD2&}Good{\c&HFAFAD2&} {\c&HFFFACD&}morning{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:02:19.27,0:02:21.47,Default-ja,,0,0,0,,{\c&HFFFFF0&}（{\c&HFFFFF0&}{\c&HFFF5EE&}圭一{\c&HFFF5EE&}{\c&HFAEBD7&}）{\c&HFAEBD7&}おはよう\N（藍子(あいこ)）おはよう
+Dialogue: 0,0:02:20.54,0:02:22.20,Default,,0,0,0,,{\c&HFFFFF0&}Good{\c&HFFFFF0&} {\c&HFFF5EE&}morning{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:02:22.30,0:02:23.33,Default,,0,0,0,,{\c&HFFFAFA&}I'm{\c&HFFFAFA&} {\c&HCCFFFF&}going{\c&HCCFFFF&} {\c&HFFFFFF&}.{\c&HFFFFFF&}
+Dialogue: 0,0:02:22.34,0:02:23.44,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}圭一{\c&HCCFFFF&}{\c&HFFFFFF&}）{\c&HFFFFFF&}いってきま～す
+Dialogue: 0,0:02:23.64,0:02:25.30,Default,,0,0,0,,{\c&HCCFFFF&}Oh{\c&HCCFFFF&} {\c&HCCFFCC&},{\c&HCCFFCC&} {\c&HFFFFCC&}Keiichi{\c&HFFFFCC&} {\c&HFFCCCC&}.{\c&HFFCCCC&}
+Dialogue: 0,0:02:23.64,0:02:24.61,Default-ja,,0,0,0,,{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HCCFFCC&}藍子{\c&HCCFFCC&}{\c&HFFFFCC&}）{\c&HFFFFCC&}{\c&HFFCCCC&}ああ{\c&HFFCCCC&}圭一
+Dialogue: 0,0:02:25.41,0:02:28.27,Default,,0,0,0,,{\c&HFFCCFF&}Thank{\c&HFFCCFF&} {\c&HCCE5FF&}Rena{\c&HCCE5FF&} {\c&HFFD8B1&}-{\c&HFFD8B1&} {\c&HCCE0FF&}chan{\c&HCCE0FF&} {\c&HFFFFE0&}for{\c&HFFFFE0&} {\c&HFFF0F5&}the{\c&HFFF0F5&} {\c&HFFE4E1&}pickles{\c&HFFE4E1&} {\c&HFAFAD2&}.{\c&HFAFAD2&}
+Dialogue: 0,0:02:25.44,0:02:28.28,Default-ja,,0,0,0,,{\c&HFFCCFF&}（{\c&HFFCCFF&}{\c&HCCE5FF&}藍子{\c&HCCE5FF&}{\c&HFFD8B1&}）{\c&HFFD8B1&}{\c&HCCE0FF&}レナ{\c&HCCE0FF&}{\c&HFFFFE0&}ちゃん{\c&HFFFFE0&}{\c&HFFF0F5&}に{\c&HFFF0F5&}{\c&HFFE4E1&}“{\c&HFFE4E1&}{\c&HFAFAD2&}お{\c&HFAFAD2&}漬物\Nありがとう”って伝えてね
+Dialogue: 0,0:02:28.38,0:02:29.34,Default,,0,0,0,,{\c&HFFFACD&}Okay{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:02:28.38,0:02:29.51,Default-ja,,0,0,0,,{\c&HFFFACD&}あ{\c&HFFFACD&}{\c&HFFEFD5&}いよ{\c&HFFEFD5&}！
+Dialogue: 0,0:02:32.21,0:02:36.15,Default,,0,0,0,,{\c&HFFFFF0&}It's{\c&HFFFFF0&} {\c&HFFF5EE&}been{\c&HFFF5EE&} {\c&HFAEBD7&}one{\c&HFAEBD7&} {\c&HFFFAFA&}month{\c&HFFFAFA&} {\c&HCCFFFF&}since{\c&HCCFFFF&} {\c&HFFFFFF&}\{\c&HFFFFFF&} {\c&HCCFFFF&}NI{\c&HCCFFFF&} {\c&HCCFFCC&}moved{\c&HCCFFCC&} {\c&HFFFFCC&}to{\c&HFFFFCC&} {\c&HFFCCCC&}Hinamizawa{\c&HFFCCCC&} {\c&HFFCCFF&}.{\c&HFFCCFF&}
+Dialogue: 0,0:02:32.31,0:02:35.32,Default-ja,,0,0,0,,{\c&HFFFFF0&}（{\c&HFFFFF0&}{\c&HFFF5EE&}圭一{\c&HFFF5EE&}{\c&HFAEBD7&}）{\c&HFAEBD7&}{\c&HFFFAFA&}\{\c&HFFFAFA&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HFFFFFF&}この{\c&HFFFFFF&}{\c&HCCFFFF&}雛{\c&HCCFFFF&}{\c&HCCFFCC&}見沢{\c&HCCFFCC&}{\c&HFFFFCC&}({\c&HFFFFCC&}{\c&HFFCCCC&}ひな{\c&HFFCCCC&}{\c&HFFCCFF&}み{\c&HFFCCFF&}ざわ)に引っ越して１か月
+Dialogue: 0,0:02:36.25,0:02:40.24,Default,,0,0,0,,{\c&HCCE5FF&}For{\c&HCCE5FF&} {\c&HFFD8B1&}the{\c&HFFD8B1&} {\c&HCCE0FF&}first{\c&HCCE0FF&} {\c&HFFFFE0&}time{\c&HFFFFE0&} {\c&HFFF0F5&},\{\c&HFFF0F5&} {\c&HFFE4E1&}NI{\c&HFFE4E1&} {\c&HFAFAD2&}learned{\c&HFAFAD2&} {\c&HFFFACD&}that{\c&HFFFACD&} {\c&HFFEFD5&}air{\c&HFFEFD5&} {\c&HFFFFF0&}can{\c&HFFFFF0&} {\c&HFFF5EE&}smell{\c&HFFF5EE&} {\c&HFAEBD7&}good{\c&HFAEBD7&} {\c&HFFFAFA&}.{\c&HFFFAFA&}
+Dialogue: 0,0:02:36.32,0:02:39.89,Default-ja,,0,0,0,,{\c&HCCE5FF&}空気{\c&HCCE5FF&}{\c&HFFD8B1&}に{\c&HFFD8B1&}{\c&HCCE0FF&}も{\c&HCCE0FF&}{\c&HFFFFE0&}味{\c&HFFFFE0&}{\c&HFFF0F5&}が{\c&HFFF0F5&}{\c&HFFE4E1&}ある{\c&HFFE4E1&}{\c&HFAFAD2&}こと{\c&HFAFAD2&}{\c&HFFFACD&}を{\c&HFFFACD&}{\c&HFFEFD5&}\{\c&HFFEFD5&}{\c&HFFFFF0&}N{\c&HFFFFF0&}{\c&HFFF5EE&}俺{\c&HFFF5EE&}{\c&HFAEBD7&}は{\c&HFAEBD7&}{\c&HFFFAFA&}初めて{\c&HFFFAFA&}知った
+Dialogue: 0,0:02:40.36,0:02:41.82,Default,,0,0,0,,{\c&HCCFFFF&}Keiichi{\c&HCCFFFF&} {\c&HFFFFFF&}-{\c&HFFFFFF&} {\c&HCCFFFF&}kun{\c&HCCFFFF&} {\c&HCCFFCC&}!{\c&HCCFFCC&}
+Dialogue: 0,0:02:40.39,0:02:43.63,Default-ja,,0,0,0,,{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HFFFFFF&}ﾚﾅ{\c&HFFFFFF&}{\c&HCCFFFF&}）{\c&HCCFFFF&}{\c&HCCFFCC&}圭一{\c&HCCFFCC&}君おっはよう！
+Dialogue: 0,0:02:42.06,0:02:43.55,Default,,0,0,0,,{\c&HFFFFCC&}Good{\c&HFFFFCC&} {\c&HFFCCCC&}morning{\c&HFFCCCC&} {\c&HFFCCFF&}!{\c&HFFCCFF&}
+Dialogue: 0,0:02:43.96,0:02:45.96,Default-ja,,0,0,0,,{\c&HFFFFCC&}（{\c&HFFFFCC&}{\c&HFFCCCC&}圭一{\c&HFFCCCC&}{\c&HFFCCFF&}）{\c&HFFCCFF&}相変わらず早(はえ)えな
 Dialogue: 0,0:02:44.09,0:02:46.25,Default,,0,0,0,,You're early, as usual.
-Dialogue: 0,0:02:46.36,0:02:49.30,Default,,0,0,0,,You could sleep in\Nonce in a while.
-Dialogue: 0,0:02:46.36,0:02:49.40,Default-ja,,0,0,0,,たまには のんびり\N朝寝坊したっていいんだぜ
-Dialogue: 0,0:02:49.66,0:02:53.07,Default,,0,0,0,,If I slept in, I'd make you wait.
-Dialogue: 0,0:02:49.70,0:02:52.93,Default-ja,,0,0,0,,お寝坊したら\N圭一君 待たせちゃうじゃない
-Dialogue: 0,0:02:53.04,0:02:54.34,Default-ja,,0,0,0,,そんときは置いてく
-Dialogue: 0,0:02:53.17,0:02:54.86,Default,,0,0,0,,And I'd ditch you.
-Dialogue: 0,0:02:54.44,0:02:56.84,Default-ja,,0,0,0,,け… 圭一君 冷た～い！
-Dialogue: 0,0:02:54.94,0:02:59.40,Default,,0,0,0,,Keiichi-kun, you're cold!\NI always wait for you!
+Dialogue: 0,0:02:46.36,0:02:49.30,Default,,0,0,0,,{\c&HCCE5FF&}You{\c&HCCE5FF&} {\c&HFFD8B1&}could{\c&HFFD8B1&} {\c&HCCE0FF&}sleep{\c&HCCE0FF&} {\c&HFFFFE0&}in{\c&HFFFFE0&} {\c&HFFF0F5&}\{\c&HFFF0F5&} {\c&HFFE4E1&}Nonce{\c&HFFE4E1&} {\c&HFAFAD2&}in{\c&HFAFAD2&} {\c&HFFFACD&}a{\c&HFFFACD&} {\c&HFFEFD5&}while{\c&HFFEFD5&} {\c&HFFFFF0&}.{\c&HFFFFF0&}
+Dialogue: 0,0:02:46.36,0:02:49.40,Default-ja,,0,0,0,,{\c&HCCE5FF&}たま{\c&HCCE5FF&}{\c&HFFD8B1&}に{\c&HFFD8B1&}{\c&HCCE0FF&}は{\c&HCCE0FF&}{\c&HFFFFE0&}のんびり{\c&HFFFFE0&}{\c&HFFF0F5&}\{\c&HFFF0F5&}{\c&HFFE4E1&}N{\c&HFFE4E1&}{\c&HFAFAD2&}朝寝坊{\c&HFAFAD2&}{\c&HFFFACD&}し{\c&HFFFACD&}{\c&HFFEFD5&}た{\c&HFFEFD5&}{\c&HFFFFF0&}って{\c&HFFFFF0&}いいんだぜ
+Dialogue: 0,0:02:49.66,0:02:53.07,Default,,0,0,0,,{\c&HFFF5EE&}If{\c&HFFF5EE&} {\c&HFAEBD7&}I{\c&HFAEBD7&} {\c&HFFFAFA&}slept{\c&HFFFAFA&} {\c&HCCFFFF&}in{\c&HCCFFFF&} {\c&HFFFFFF&},{\c&HFFFFFF&} {\c&HCCFFFF&}I'd{\c&HCCFFFF&} {\c&HCCFFCC&}make{\c&HCCFFCC&} {\c&HFFFFCC&}you{\c&HFFFFCC&} {\c&HFFCCCC&}wait{\c&HFFCCCC&} {\c&HFFCCFF&}.{\c&HFFCCFF&}
+Dialogue: 0,0:02:49.70,0:02:52.93,Default-ja,,0,0,0,,{\c&HFFF5EE&}お{\c&HFFF5EE&}{\c&HFAEBD7&}寝坊{\c&HFAEBD7&}{\c&HFFFAFA&}し{\c&HFFFAFA&}{\c&HCCFFFF&}たら{\c&HCCFFFF&}{\c&HFFFFFF&}\{\c&HFFFFFF&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HCCFFCC&}圭一{\c&HCCFFCC&}{\c&HFFFFCC&}君{\c&HFFFFCC&}{\c&HFFCCCC&}待た{\c&HFFCCCC&}{\c&HFFCCFF&}せ{\c&HFFCCFF&}ちゃうじゃない
+Dialogue: 0,0:02:53.04,0:02:54.34,Default-ja,,0,0,0,,{\c&HCCE5FF&}そん{\c&HCCE5FF&}{\c&HFFD8B1&}とき{\c&HFFD8B1&}{\c&HCCE0FF&}は{\c&HCCE0FF&}{\c&HFFFFE0&}置い{\c&HFFFFE0&}{\c&HFFF0F5&}て{\c&HFFF0F5&}く
+Dialogue: 0,0:02:53.17,0:02:54.86,Default,,0,0,0,,{\c&HCCE5FF&}And{\c&HCCE5FF&} {\c&HFFD8B1&}I'd{\c&HFFD8B1&} {\c&HCCE0FF&}ditch{\c&HCCE0FF&} {\c&HFFFFE0&}you{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:02:54.44,0:02:56.84,Default-ja,,0,0,0,,{\c&HFFE4E1&}け{\c&HFFE4E1&}{\c&HFAFAD2&}…{\c&HFAFAD2&}{\c&HFFFACD&}圭一{\c&HFFFACD&}{\c&HFFEFD5&}君{\c&HFFEFD5&}{\c&HFFFFF0&}冷た{\c&HFFFFF0&}{\c&HFFF5EE&}～{\c&HFFF5EE&}{\c&HFAEBD7&}い{\c&HFAEBD7&}{\c&HFFFAFA&}！{\c&HFFFAFA&}
+Dialogue: 0,0:02:54.94,0:02:59.40,Default,,0,0,0,,{\c&HFFE4E1&}Keiichi{\c&HFFE4E1&} {\c&HFAFAD2&}-{\c&HFAFAD2&} {\c&HFFFACD&}kun{\c&HFFFACD&} {\c&HFFEFD5&},{\c&HFFEFD5&} {\c&HFFFFF0&}you're{\c&HFFFFF0&} {\c&HFFF5EE&}cold{\c&HFFF5EE&} {\c&HFAEBD7&}!\{\c&HFAEBD7&} {\c&HFFFAFA&}NI{\c&HFFFAFA&} always wait for you !
 Dialogue: 0,0:02:56.94,0:02:59.51,Default-ja,,0,0,0,,いつも 待っててあげてるのに…
-Dialogue: 0,0:02:59.71,0:03:02.68,Default-ja,,0,0,0,,サクサク置いてく\Nキリキリ置いてく
-Dialogue: 0,0:02:59.77,0:03:03.30,Default,,0,0,0,,I'd just ditch you\Nwithout any hesitation.
-Dialogue: 0,0:03:03.41,0:03:06.24,Default,,0,0,0,,Why are you so cold? Why?
-Dialogue: 0,0:03:03.45,0:03:06.38,Default-ja,,0,0,0,,どうして冷たいんだろう？\Nだろう？
-Dialogue: 0,0:03:07.45,0:03:10.21,Default,,0,0,0,,I'm kidding. I'd wait for sure.
-Dialogue: 0,0:03:07.48,0:03:09.65,Default-ja,,0,0,0,,ウソ　ちゃんと待ってるよ
-Dialogue: 0,0:03:10.32,0:03:13.79,Default-ja,,0,0,0,,アア… あ… ありがとう
-Dialogue: 0,0:03:11.52,0:03:13.51,Default,,0,0,0,,T-Thanks...
-Dialogue: 0,0:03:14.42,0:03:18.45,Default,,0,0,0,,This weird one who easily\Nblushes is Rena Ryugu.
-Dialogue: 0,0:03:14.49,0:03:18.56,Default-ja,,0,0,0,,（圭一）この すぐ真っ赤になって\Nポ～ッとする変なヤツは 竜宮(りゅうぐう)レナ
+Dialogue: 0,0:02:59.71,0:03:02.68,Default-ja,,0,0,0,,{\c&HCCFFFF&}サクサク{\c&HCCFFFF&}{\c&HFFFFFF&}置い{\c&HFFFFFF&}{\c&HCCFFFF&}て{\c&HCCFFFF&}{\c&HCCFFCC&}く{\c&HCCFFCC&}{\c&HFFFFCC&}\{\c&HFFFFCC&}{\c&HFFCCCC&}N{\c&HFFCCCC&}{\c&HFFCCFF&}キリキリ{\c&HFFCCFF&}{\c&HCCE5FF&}置い{\c&HCCE5FF&}{\c&HFFD8B1&}て{\c&HFFD8B1&}く
+Dialogue: 0,0:02:59.77,0:03:03.30,Default,,0,0,0,,{\c&HCCFFFF&}I'd{\c&HCCFFFF&} {\c&HFFFFFF&}just{\c&HFFFFFF&} {\c&HCCFFFF&}ditch{\c&HCCFFFF&} {\c&HCCFFCC&}you{\c&HCCFFCC&} {\c&HFFFFCC&}\{\c&HFFFFCC&} {\c&HFFCCCC&}Nwithout{\c&HFFCCCC&} {\c&HFFCCFF&}any{\c&HFFCCFF&} {\c&HCCE5FF&}hesitation{\c&HCCE5FF&} {\c&HFFD8B1&}.{\c&HFFD8B1&}
+Dialogue: 0,0:03:03.41,0:03:06.24,Default,,0,0,0,,{\c&HCCE0FF&}Why{\c&HCCE0FF&} {\c&HFFFFE0&}are{\c&HFFFFE0&} {\c&HFFF0F5&}you{\c&HFFF0F5&} {\c&HFFE4E1&}so{\c&HFFE4E1&} {\c&HFAFAD2&}cold{\c&HFAFAD2&} {\c&HFFFACD&}?{\c&HFFFACD&} {\c&HFFEFD5&}Why{\c&HFFEFD5&} {\c&HFFFFF0&}?{\c&HFFFFF0&}
+Dialogue: 0,0:03:03.45,0:03:06.38,Default-ja,,0,0,0,,{\c&HCCE0FF&}どうして{\c&HCCE0FF&}{\c&HFFFFE0&}冷たい{\c&HFFFFE0&}{\c&HFFF0F5&}ん{\c&HFFF0F5&}{\c&HFFE4E1&}だろ{\c&HFFE4E1&}{\c&HFAFAD2&}う{\c&HFAFAD2&}{\c&HFFFACD&}？{\c&HFFFACD&}{\c&HFFEFD5&}\{\c&HFFEFD5&}{\c&HFFFFF0&}N{\c&HFFFFF0&}だろう？
+Dialogue: 0,0:03:07.45,0:03:10.21,Default,,0,0,0,,{\c&HFFF5EE&}I'm{\c&HFFF5EE&} {\c&HFAEBD7&}kidding{\c&HFAEBD7&} {\c&HFFFAFA&}.{\c&HFFFAFA&} {\c&HCCFFFF&}I'd{\c&HCCFFFF&} {\c&HFFFFFF&}wait{\c&HFFFFFF&} {\c&HCCFFFF&}for{\c&HCCFFFF&} sure .
+Dialogue: 0,0:03:07.48,0:03:09.65,Default-ja,,0,0,0,,{\c&HFFF5EE&}ウソ{\c&HFFF5EE&}{\c&HFAEBD7&}　{\c&HFAEBD7&}{\c&HFFFAFA&}ちゃんと{\c&HFFFAFA&}{\c&HCCFFFF&}待っ{\c&HCCFFFF&}{\c&HFFFFFF&}てる{\c&HFFFFFF&}{\c&HCCFFFF&}よ{\c&HCCFFFF&}
+Dialogue: 0,0:03:10.32,0:03:13.79,Default-ja,,0,0,0,,{\c&HCCFFCC&}アア{\c&HCCFFCC&}{\c&HFFFFCC&}…{\c&HFFFFCC&}{\c&HFFCCCC&}あ{\c&HFFCCCC&}{\c&HFFCCFF&}…{\c&HFFCCFF&}ありがとう
+Dialogue: 0,0:03:11.52,0:03:13.51,Default,,0,0,0,,{\c&HCCFFCC&}T{\c&HCCFFCC&} {\c&HFFFFCC&}-{\c&HFFFFCC&} {\c&HFFCCCC&}Thanks{\c&HFFCCCC&} {\c&HFFCCFF&}...{\c&HFFCCFF&}
+Dialogue: 0,0:03:14.42,0:03:18.45,Default,,0,0,0,,{\c&HCCE5FF&}This{\c&HCCE5FF&} {\c&HFFD8B1&}weird{\c&HFFD8B1&} {\c&HCCE0FF&}one{\c&HCCE0FF&} {\c&HFFFFE0&}who{\c&HFFFFE0&} {\c&HFFF0F5&}easily{\c&HFFF0F5&} {\c&HFFE4E1&}\{\c&HFFE4E1&} {\c&HFAFAD2&}Nblushes{\c&HFAFAD2&} {\c&HFFFACD&}is{\c&HFFFACD&} {\c&HFFEFD5&}Rena{\c&HFFEFD5&} {\c&HFFFFF0&}Ryugu{\c&HFFFFF0&} {\c&HFFF5EE&}.{\c&HFFF5EE&}
+Dialogue: 0,0:03:14.49,0:03:18.56,Default-ja,,0,0,0,,{\c&HCCE5FF&}（{\c&HCCE5FF&}{\c&HFFD8B1&}圭一{\c&HFFD8B1&}{\c&HCCE0FF&}）{\c&HCCE0FF&}{\c&HFFFFE0&}この{\c&HFFFFE0&}{\c&HFFF0F5&}すぐ{\c&HFFF0F5&}{\c&HFFE4E1&}真っ赤{\c&HFFE4E1&}{\c&HFAFAD2&}に{\c&HFAFAD2&}{\c&HFFFACD&}なっ{\c&HFFFACD&}{\c&HFFEFD5&}て{\c&HFFEFD5&}{\c&HFFFFF0&}\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}ポ～ッとする変なヤツは竜宮(りゅうぐう)レナ
 Dialogue: 0,0:03:18.79,0:03:19.36,Default,,0,0,0,,Oh, I have\Na message from my mom.
-Dialogue: 0,0:03:19.36,0:03:22.00,Default,,0,0,0,,Oh, I have\Na message from my mom.\NI've known her\Nless than a month...
-Dialogue: 0,0:03:19.39,0:03:21.80,Default-ja,,0,0,0,,まだ知り合って\Nひと月も たってないが―
-Dialogue: 0,0:03:21.90,0:03:24.03,Default-ja,,0,0,0,,変わってるのは\N名前だけじゃないことは―
-Dialogue: 0,0:03:22.00,0:03:22.66,Default,,0,0,0,,Oh, I have\Na message from my mom.\N...but I know her name isn't\Nthe only weird thing about her.
-Dialogue: 0,0:03:22.66,0:03:25.03,Default,,0,0,0,,"Thanks for the pickles."\N...but I know her name isn't\Nthe only weird thing about her.
-Dialogue: 0,0:03:24.33,0:03:25.53,Default-ja,,0,0,0,,よく分かる
+Dialogue: 0,0:03:19.36,0:03:22.00,Default,,0,0,0,,{\c&HFAEBD7&}Oh{\c&HFAEBD7&} {\c&HFFFAFA&},{\c&HFFFAFA&} {\c&HCCFFFF&}I{\c&HCCFFFF&} {\c&HFFFFFF&}have{\c&HFFFFFF&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HCCFFCC&}Na{\c&HCCFFCC&} {\c&HFFFFCC&}message{\c&HFFFFCC&} {\c&HFFCCCC&}from{\c&HFFCCCC&} {\c&HFFCCFF&}my{\c&HFFCCFF&} {\c&HCCE5FF&}mom{\c&HCCE5FF&} {\c&HFFD8B1&}.\{\c&HFFD8B1&} NI've known her \ Nless than a month ...
+Dialogue: 0,0:03:19.39,0:03:21.80,Default-ja,,0,0,0,,{\c&HFAEBD7&}まだ{\c&HFAEBD7&}{\c&HFFFAFA&}知り合っ{\c&HFFFAFA&}{\c&HCCFFFF&}て{\c&HCCFFFF&}{\c&HFFFFFF&}\{\c&HFFFFFF&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HCCFFCC&}ひと月{\c&HCCFFCC&}{\c&HFFFFCC&}も{\c&HFFFFCC&}{\c&HFFCCCC&}たって{\c&HFFCCCC&}{\c&HFFCCFF&}ない{\c&HFFCCFF&}{\c&HCCE5FF&}が{\c&HCCE5FF&}{\c&HFFD8B1&}―{\c&HFFD8B1&}
+Dialogue: 0,0:03:21.90,0:03:24.03,Default-ja,,0,0,0,,{\c&HCCE0FF&}変わっ{\c&HCCE0FF&}{\c&HFFFFE0&}てる{\c&HFFFFE0&}{\c&HFFF0F5&}の{\c&HFFF0F5&}{\c&HFFE4E1&}は{\c&HFFE4E1&}{\c&HFAFAD2&}\{\c&HFAFAD2&}{\c&HFFFACD&}N{\c&HFFFACD&}{\c&HFFEFD5&}名前{\c&HFFEFD5&}{\c&HFFFFF0&}だけ{\c&HFFFFF0&}{\c&HFFF5EE&}じゃ{\c&HFFF5EE&}{\c&HFAEBD7&}ない{\c&HFAEBD7&}{\c&HFFFAFA&}こと{\c&HFFFAFA&}{\c&HCCFFFF&}は{\c&HCCFFFF&}{\c&HFFFFFF&}―{\c&HFFFFFF&}
+Dialogue: 0,0:03:22.00,0:03:22.66,Default,,0,0,0,,{\c&HCCE0FF&}Oh{\c&HCCE0FF&} {\c&HFFFFE0&},{\c&HFFFFE0&} {\c&HFFF0F5&}I{\c&HFFF0F5&} {\c&HFFE4E1&}have{\c&HFFE4E1&} {\c&HFAFAD2&}\{\c&HFAFAD2&} {\c&HFFFACD&}Na{\c&HFFFACD&} {\c&HFFEFD5&}message{\c&HFFEFD5&} {\c&HFFFFF0&}from{\c&HFFFFF0&} {\c&HFFF5EE&}my{\c&HFFF5EE&} {\c&HFAEBD7&}mom{\c&HFAEBD7&} {\c&HFFFAFA&}.\{\c&HFFFAFA&} {\c&HCCFFFF&}N{\c&HCCFFFF&} {\c&HFFFFFF&}...{\c&HFFFFFF&} but I know her name isn't \ Nthe only weird thing about her .
+Dialogue: 0,0:03:22.66,0:03:25.03,Default,,0,0,0,,{\c&HCCFFFF&}"{\c&HCCFFFF&} {\c&HCCFFCC&}Thanks{\c&HCCFFCC&} for the pickles ."\ N ... but I know her name isn't \ Nthe only weird thing about her .
+Dialogue: 0,0:03:24.33,0:03:25.53,Default-ja,,0,0,0,,{\c&HCCFFFF&}よく{\c&HCCFFFF&}{\c&HCCFFCC&}分かる{\c&HCCFFCC&}
 Dialogue: 0,0:03:25.03,0:03:25.87,Default,,0,0,0,,N-No problem.\N...but I know her name isn't\Nthe only weird thing about her.
-Dialogue: 0,0:03:25.87,0:03:26.53,Default,,0,0,0,,N-No problem.
-Dialogue: 0,0:03:26.60,0:03:29.04,Default-ja,,0,0,0,,どういたしまして フフッ…
-Dialogue: 0,0:03:26.63,0:03:28.30,Default,,0,0,0,,You're welcome.
-Dialogue: 0,0:03:29.50,0:03:33.11,Default-ja,,0,0,0,,（魅音(みおん)）オッ！ 来た来た\N遅いよ ２人とも
+Dialogue: 0,0:03:25.87,0:03:26.53,Default,,0,0,0,,{\c&HFFFFCC&}N{\c&HFFFFCC&} {\c&HFFCCCC&}-{\c&HFFCCCC&} {\c&HFFCCFF&}No{\c&HFFCCFF&} problem .
+Dialogue: 0,0:03:26.60,0:03:29.04,Default-ja,,0,0,0,,{\c&HFFFFCC&}どういたしまして{\c&HFFFFCC&}{\c&HFFCCCC&}フフッ{\c&HFFCCCC&}{\c&HFFCCFF&}…{\c&HFFCCFF&}
+Dialogue: 0,0:03:26.63,0:03:28.30,Default,,0,0,0,,{\c&HCCE5FF&}You're{\c&HCCE5FF&} {\c&HFFD8B1&}welcome{\c&HFFD8B1&} {\c&HCCE0FF&}.{\c&HCCE0FF&}
+Dialogue: 0,0:03:29.50,0:03:33.11,Default-ja,,0,0,0,,{\c&HCCE5FF&}（{\c&HCCE5FF&}{\c&HFFD8B1&}魅{\c&HFFD8B1&}{\c&HCCE0FF&}音{\c&HCCE0FF&}(みおん)）オッ！来た来た\N遅いよ２人とも
 Dialogue: 0,0:03:30.10,0:03:31.54,Default,,0,0,0,,There you are.
 Dialogue: 0,0:03:31.64,0:03:33.16,Default,,0,0,0,,You're both late.
-Dialogue: 0,0:03:33.64,0:03:35.70,Default,,0,0,0,,Good morning, Mi-chan!
-Dialogue: 0,0:03:33.64,0:03:35.68,Default-ja,,0,0,0,,魅(み)ぃちゃん おっはよう！
-Dialogue: 0,0:03:35.78,0:03:38.48,Default-ja,,0,0,0,,いつも遅いのは お前のほうだろう
-Dialogue: 0,0:03:35.81,0:03:38.40,Default,,0,0,0,,You're the one who's always late.
-Dialogue: 0,0:03:38.68,0:03:42.52,Default-ja,,0,0,0,,圭ちゃん お久しぶり\N何年ぶりだっけ？
-Dialogue: 0,0:03:38.71,0:03:42.91,Default,,0,0,0,,Long time no see, Kei-chan.\NHow many years was it?
-Dialogue: 0,0:03:42.92,0:03:45.92,Default-ja,,0,0,0,,２日しか休んでねえよ\N（魅音）アハハハッ…
-Dialogue: 0,0:03:43.02,0:03:45.49,Default,,0,0,0,,I was absent for two days.
-Dialogue: 0,0:03:46.02,0:03:49.66,Default-ja,,0,0,0,,レナの律儀さとは別に\Nマイペースなヤツ
-Dialogue: 0,0:03:46.12,0:03:46.42,Default,,0,0,0,,Unlike the conscientious Rena,\Nshe goes at her own pace.
+Dialogue: 0,0:03:33.64,0:03:35.70,Default,,0,0,0,,{\c&HFFFFE0&}Good{\c&HFFFFE0&} {\c&HFFF0F5&}morning{\c&HFFF0F5&} {\c&HFFE4E1&},{\c&HFFE4E1&} {\c&HFAFAD2&}Mi{\c&HFAFAD2&} {\c&HFFFACD&}-{\c&HFFFACD&} {\c&HFFEFD5&}chan{\c&HFFEFD5&} {\c&HFFFFF0&}!{\c&HFFFFF0&}
+Dialogue: 0,0:03:33.64,0:03:35.68,Default-ja,,0,0,0,,{\c&HFFFFE0&}魅{\c&HFFFFE0&}{\c&HFFF0F5&}({\c&HFFF0F5&}{\c&HFFE4E1&}み{\c&HFFE4E1&}{\c&HFAFAD2&}){\c&HFAFAD2&}{\c&HFFFACD&}ぃちゃん{\c&HFFFACD&}{\c&HFFEFD5&}おっ{\c&HFFEFD5&}{\c&HFFFFF0&}はよう{\c&HFFFFF0&}！
+Dialogue: 0,0:03:35.78,0:03:38.48,Default-ja,,0,0,0,,{\c&HFFF5EE&}いつも{\c&HFFF5EE&}{\c&HFAEBD7&}遅い{\c&HFAEBD7&}{\c&HFFFAFA&}の{\c&HFFFAFA&}{\c&HCCFFFF&}は{\c&HCCFFFF&}{\c&HFFFFFF&}お前{\c&HFFFFFF&}{\c&HCCFFFF&}の{\c&HCCFFFF&}{\c&HCCFFCC&}ほう{\c&HCCFFCC&}だろう
+Dialogue: 0,0:03:35.81,0:03:38.40,Default,,0,0,0,,{\c&HFFF5EE&}You're{\c&HFFF5EE&} {\c&HFAEBD7&}the{\c&HFAEBD7&} {\c&HFFFAFA&}one{\c&HFFFAFA&} {\c&HCCFFFF&}who's{\c&HCCFFFF&} {\c&HFFFFFF&}always{\c&HFFFFFF&} {\c&HCCFFFF&}late{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:03:38.68,0:03:42.52,Default-ja,,0,0,0,,{\c&HFFFFCC&}圭{\c&HFFFFCC&}{\c&HFFCCCC&}ちゃん{\c&HFFCCCC&}{\c&HFFCCFF&}お{\c&HFFCCFF&}{\c&HCCE5FF&}久しぶり{\c&HCCE5FF&}{\c&HFFD8B1&}\{\c&HFFD8B1&}{\c&HCCE0FF&}N{\c&HCCE0FF&}{\c&HFFFFE0&}何{\c&HFFFFE0&}{\c&HFFF0F5&}年{\c&HFFF0F5&}{\c&HFFE4E1&}ぶり{\c&HFFE4E1&}{\c&HFAFAD2&}だ{\c&HFAFAD2&}{\c&HFFFACD&}っけ{\c&HFFFACD&}{\c&HFFEFD5&}？{\c&HFFEFD5&}
+Dialogue: 0,0:03:38.71,0:03:42.91,Default,,0,0,0,,{\c&HFFFFCC&}Long{\c&HFFFFCC&} {\c&HFFCCCC&}time{\c&HFFCCCC&} {\c&HFFCCFF&}no{\c&HFFCCFF&} {\c&HCCE5FF&}see{\c&HCCE5FF&} {\c&HFFD8B1&},{\c&HFFD8B1&} {\c&HCCE0FF&}Kei{\c&HCCE0FF&} {\c&HFFFFE0&}-{\c&HFFFFE0&} {\c&HFFF0F5&}chan{\c&HFFF0F5&} {\c&HFFE4E1&}.\{\c&HFFE4E1&} {\c&HFAFAD2&}NHow{\c&HFAFAD2&} {\c&HFFFACD&}many{\c&HFFFACD&} {\c&HFFEFD5&}years{\c&HFFEFD5&} was it ?
+Dialogue: 0,0:03:42.92,0:03:45.92,Default-ja,,0,0,0,,{\c&HFFFFF0&}２{\c&HFFFFF0&}{\c&HFFF5EE&}日{\c&HFFF5EE&}{\c&HFAEBD7&}しか{\c&HFAEBD7&}{\c&HFFFAFA&}休ん{\c&HFFFAFA&}{\c&HCCFFFF&}で{\c&HCCFFFF&}{\c&HFFFFFF&}ねえ{\c&HFFFFFF&}{\c&HCCFFFF&}よ{\c&HCCFFFF&}\N（魅音）アハハハッ…
+Dialogue: 0,0:03:43.02,0:03:45.49,Default,,0,0,0,,{\c&HFFFFF0&}I{\c&HFFFFF0&} {\c&HFFF5EE&}was{\c&HFFF5EE&} {\c&HFAEBD7&}absent{\c&HFAEBD7&} {\c&HFFFAFA&}for{\c&HFFFAFA&} {\c&HCCFFFF&}two{\c&HCCFFFF&} {\c&HFFFFFF&}days{\c&HFFFFFF&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:03:46.02,0:03:49.66,Default-ja,,0,0,0,,{\c&HCCFFCC&}レナ{\c&HCCFFCC&}{\c&HFFFFCC&}の{\c&HFFFFCC&}{\c&HFFCCCC&}律儀{\c&HFFCCCC&}{\c&HFFCCFF&}さ{\c&HFFCCFF&}{\c&HCCE5FF&}と{\c&HCCE5FF&}{\c&HFFD8B1&}は{\c&HFFD8B1&}{\c&HCCE0FF&}別に{\c&HCCE0FF&}{\c&HFFFFE0&}\{\c&HFFFFE0&}{\c&HFFF0F5&}N{\c&HFFF0F5&}{\c&HFFE4E1&}マイペース{\c&HFFE4E1&}{\c&HFAFAD2&}な{\c&HFAFAD2&}{\c&HFFFACD&}ヤツ{\c&HFFFACD&}
+Dialogue: 0,0:03:46.12,0:03:46.42,Default,,0,0,0,,{\c&HCCFFCC&}Unlike{\c&HCCFFCC&} {\c&HFFFFCC&}the{\c&HFFFFCC&} {\c&HFFCCCC&}conscientious{\c&HFFCCCC&} {\c&HFFCCFF&}Rena{\c&HFFCCFF&} {\c&HCCE5FF&},\{\c&HCCE5FF&} {\c&HFFD8B1&}Nshe{\c&HFFD8B1&} {\c&HCCE0FF&}goes{\c&HCCE0FF&} {\c&HFFFFE0&}at{\c&HFFFFE0&} {\c&HFFF0F5&}her{\c&HFFF0F5&} {\c&HFFE4E1&}own{\c&HFFE4E1&} {\c&HFAFAD2&}pace{\c&HFAFAD2&} {\c&HFFFACD&}.{\c&HFFFACD&}
 Dialogue: 0,0:03:46.42,0:03:50.39,Default,,0,0,0,,Oh, really. You were so cute\Nthe last time I saw you!\NUnlike the conscientious Rena,\Nshe goes at her own pace.
-Dialogue: 0,0:03:50.39,0:03:50.99,Default,,0,0,0,,Oh, really. You were so cute\Nthe last time I saw you!\NMion Sonozaki.
-Dialogue: 0,0:03:50.43,0:03:54.10,Default-ja,,0,0,0,,こいつは園崎(そのざき)魅音　一応 上級生で\Nクラスのリーダー役だ
+Dialogue: 0,0:03:50.39,0:03:50.99,Default,,0,0,0,,{\c&HFFEFD5&}Oh{\c&HFFEFD5&} {\c&HFFFFF0&},{\c&HFFFFF0&} {\c&HFFF5EE&}really{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&} {\c&HFFFAFA&}You{\c&HFFFAFA&} {\c&HCCFFFF&}were{\c&HCCFFFF&} {\c&HFFFFFF&}so{\c&HFFFFFF&} {\c&HCCFFFF&}cute{\c&HCCFFFF&} {\c&HCCFFCC&}\{\c&HCCFFCC&} {\c&HFFFFCC&}Nthe{\c&HFFFFCC&} {\c&HFFCCCC&}last{\c&HFFCCCC&} {\c&HFFCCFF&}time{\c&HFFCCFF&} {\c&HCCE5FF&}I{\c&HCCE5FF&} {\c&HFFD8B1&}saw{\c&HFFD8B1&} {\c&HCCE0FF&}you{\c&HCCE0FF&} {\c&HFFFFE0&}!\{\c&HFFFFE0&} {\c&HFFF0F5&}NMion{\c&HFFF0F5&} {\c&HFFE4E1&}Sonozaki{\c&HFFE4E1&} {\c&HFAFAD2&}.{\c&HFAFAD2&}
+Dialogue: 0,0:03:50.43,0:03:54.10,Default-ja,,0,0,0,,{\c&HFFEFD5&}こいつ{\c&HFFEFD5&}{\c&HFFFFF0&}は{\c&HFFFFF0&}{\c&HFFF5EE&}園{\c&HFFF5EE&}{\c&HFAEBD7&}崎{\c&HFAEBD7&}{\c&HFFFAFA&}({\c&HFFFAFA&}{\c&HCCFFFF&}その{\c&HCCFFFF&}{\c&HFFFFFF&}ざき{\c&HFFFFFF&}{\c&HCCFFFF&}){\c&HCCFFFF&}{\c&HCCFFCC&}魅{\c&HCCFFCC&}{\c&HFFFFCC&}音{\c&HFFFFCC&}{\c&HFFCCCC&}　{\c&HFFCCCC&}{\c&HFFCCFF&}一応{\c&HFFCCFF&}{\c&HCCE5FF&}上級生{\c&HCCE5FF&}{\c&HFFD8B1&}で{\c&HFFD8B1&}{\c&HCCE0FF&}\{\c&HCCE0FF&}{\c&HFFFFE0&}N{\c&HFFFFE0&}{\c&HFFF0F5&}クラス{\c&HFFF0F5&}{\c&HFFE4E1&}の{\c&HFFE4E1&}{\c&HFAFAD2&}リーダー{\c&HFAFAD2&}役だ
 Dialogue: 0,0:03:50.99,0:03:52.29,Default,,0,0,0,,What are you talking about?\NMion Sonozaki.
 Dialogue: 0,0:03:52.29,0:03:53.80,Default,,0,0,0,,What are you talking about?\NAn upperclassman\Nwho's like the class leader.
-Dialogue: 0,0:03:53.80,0:03:56.76,Default,,0,0,0,,So how was it being\Nback in the city?\NAn upperclassman\Nwho's like the class leader.
-Dialogue: 0,0:03:54.40,0:03:56.80,Default-ja,,0,0,0,,（魅音）\Nどうだった？ 久しぶりの都会はさ
-Dialogue: 0,0:03:57.07,0:04:01.44,Default-ja,,0,0,0,,葬式で行っただけだぜ\N慌ただしいだけだったよ
-Dialogue: 0,0:03:57.20,0:04:01.40,Default,,0,0,0,,I only went for a funeral.\NIt was just really busy.
-Dialogue: 0,0:04:01.50,0:04:04.67,Default,,0,0,0,,So did you get what I asked for?
-Dialogue: 0,0:04:01.54,0:04:03.37,Default-ja,,0,0,0,,（魅音）\N…でさ 探しといてくれた？
-Dialogue: 0,0:04:03.47,0:04:04.67,Default-ja,,0,0,0,,頼んどいたやつ
-Dialogue: 0,0:04:04.77,0:04:07.87,Default,,0,0,0,,I told you I was at a funeral!
-Dialogue: 0,0:04:04.77,0:04:07.88,Default-ja,,0,0,0,,（圭一）\Nだから！ 俺は葬式に行ったの！
-Dialogue: 0,0:04:08.84,0:04:11.44,Default,,0,0,0,,Hinamizawa is a small village...
-Dialogue: 0,0:04:08.84,0:04:13.98,Default-ja,,0,0,0,,ここ雛見沢は小さな村で\N学校どころかクラスも１つしかない
-Dialogue: 0,0:04:11.55,0:04:14.48,Default,,0,0,0,,...so it only has\None school with one class.
-Dialogue: 0,0:04:14.58,0:04:17.48,Default,,0,0,0,,The class is mixed\Nages and grades.
-Dialogue: 0,0:04:14.58,0:04:17.49,Default-ja,,0,0,0,,そのクラスも\N年齢 学年 バラバラで
-Dialogue: 0,0:04:17.59,0:04:21.61,Default,,0,0,0,,It's a lonely village with a total\Nof about fifteen students.
-Dialogue: 0,0:04:17.59,0:04:21.69,Default-ja,,0,0,0,,全員 足しても\N15人いるかどうかという寒村ぶりだ
-Dialogue: 0,0:04:22.16,0:04:23.69,Default-ja,,0,0,0,,先生も１人
-Dialogue: 0,0:04:22.29,0:04:23.72,Default,,0,0,0,,There's one teacher.
-Dialogue: 0,0:04:23.79,0:04:27.00,Default-ja,,0,0,0,,学年が違うごとに 違うことを\N教えなければいけないのだから―
-Dialogue: 0,0:04:23.83,0:04:28.85,Default,,0,0,0,,It must be hard to teach different\Nthings to each grade level.
+Dialogue: 0,0:03:53.80,0:03:56.76,Default,,0,0,0,,{\c&HFFFACD&}So{\c&HFFFACD&} {\c&HFFEFD5&}how{\c&HFFEFD5&} {\c&HFFFFF0&}was{\c&HFFFFF0&} {\c&HFFF5EE&}it{\c&HFFF5EE&} {\c&HFAEBD7&}being{\c&HFAEBD7&} {\c&HFFFAFA&}\{\c&HFFFAFA&} {\c&HCCFFFF&}Nback{\c&HCCFFFF&} {\c&HFFFFFF&}in{\c&HFFFFFF&} {\c&HCCFFFF&}the{\c&HCCFFFF&} {\c&HCCFFCC&}city{\c&HCCFFCC&} {\c&HFFFFCC&}?\{\c&HFFFFCC&} {\c&HFFCCCC&}NAn{\c&HFFCCCC&} {\c&HFFCCFF&}upperclassman{\c&HFFCCFF&} {\c&HCCE5FF&}\{\c&HCCE5FF&} {\c&HFFD8B1&}Nwho's{\c&HFFD8B1&} like the class leader .
+Dialogue: 0,0:03:54.40,0:03:56.80,Default-ja,,0,0,0,,{\c&HFFFACD&}（{\c&HFFFACD&}{\c&HFFEFD5&}魅{\c&HFFEFD5&}{\c&HFFFFF0&}音{\c&HFFFFF0&}{\c&HFFF5EE&}）{\c&HFFF5EE&}{\c&HFAEBD7&}\{\c&HFAEBD7&}{\c&HFFFAFA&}N{\c&HFFFAFA&}{\c&HCCFFFF&}どう{\c&HCCFFFF&}{\c&HFFFFFF&}だっ{\c&HFFFFFF&}{\c&HCCFFFF&}た{\c&HCCFFFF&}{\c&HCCFFCC&}？{\c&HCCFFCC&}{\c&HFFFFCC&}久しぶり{\c&HFFFFCC&}{\c&HFFCCCC&}の{\c&HFFCCCC&}{\c&HFFCCFF&}都会{\c&HFFCCFF&}{\c&HCCE5FF&}は{\c&HCCE5FF&}{\c&HFFD8B1&}さ{\c&HFFD8B1&}
+Dialogue: 0,0:03:57.07,0:04:01.44,Default-ja,,0,0,0,,{\c&HCCE0FF&}葬式{\c&HCCE0FF&}{\c&HFFFFE0&}で{\c&HFFFFE0&}{\c&HFFF0F5&}行っ{\c&HFFF0F5&}{\c&HFFE4E1&}た{\c&HFFE4E1&}{\c&HFAFAD2&}だけ{\c&HFAFAD2&}{\c&HFFFACD&}だ{\c&HFFFACD&}{\c&HFFEFD5&}ぜ{\c&HFFEFD5&}{\c&HFFFFF0&}\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}{\c&HFAEBD7&}慌ただしい{\c&HFAEBD7&}{\c&HFFFAFA&}だけ{\c&HFFFAFA&}{\c&HCCFFFF&}だっ{\c&HCCFFFF&}{\c&HFFFFFF&}た{\c&HFFFFFF&}よ
+Dialogue: 0,0:03:57.20,0:04:01.40,Default,,0,0,0,,{\c&HCCE0FF&}I{\c&HCCE0FF&} {\c&HFFFFE0&}only{\c&HFFFFE0&} {\c&HFFF0F5&}went{\c&HFFF0F5&} {\c&HFFE4E1&}for{\c&HFFE4E1&} {\c&HFAFAD2&}a{\c&HFAFAD2&} {\c&HFFFACD&}funeral{\c&HFFFACD&} {\c&HFFEFD5&}.\{\c&HFFEFD5&} {\c&HFFFFF0&}NIt{\c&HFFFFF0&} {\c&HFFF5EE&}was{\c&HFFF5EE&} {\c&HFAEBD7&}just{\c&HFAEBD7&} {\c&HFFFAFA&}really{\c&HFFFAFA&} {\c&HCCFFFF&}busy{\c&HCCFFFF&} {\c&HFFFFFF&}.{\c&HFFFFFF&}
+Dialogue: 0,0:04:01.50,0:04:04.67,Default,,0,0,0,,{\c&HCCFFFF&}So{\c&HCCFFFF&} {\c&HCCFFCC&}did{\c&HCCFFCC&} {\c&HFFFFCC&}you{\c&HFFFFCC&} {\c&HFFCCCC&}get{\c&HFFCCCC&} {\c&HFFCCFF&}what{\c&HFFCCFF&} {\c&HCCE5FF&}I{\c&HCCE5FF&} {\c&HFFD8B1&}asked{\c&HFFD8B1&} {\c&HCCE0FF&}for{\c&HCCE0FF&} {\c&HFFFFE0&}?{\c&HFFFFE0&}
+Dialogue: 0,0:04:01.54,0:04:03.37,Default-ja,,0,0,0,,{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HCCFFCC&}魅{\c&HCCFFCC&}{\c&HFFFFCC&}音{\c&HFFFFCC&}{\c&HFFCCCC&}）{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}{\c&HFFD8B1&}…{\c&HFFD8B1&}{\c&HCCE0FF&}で{\c&HCCE0FF&}{\c&HFFFFE0&}さ{\c&HFFFFE0&}探しといてくれた？
+Dialogue: 0,0:04:03.47,0:04:04.67,Default-ja,,0,0,0,,{\c&HFFF0F5&}頼ん{\c&HFFF0F5&}{\c&HFFE4E1&}どい{\c&HFFE4E1&}{\c&HFAFAD2&}た{\c&HFAFAD2&}{\c&HFFFACD&}やつ{\c&HFFFACD&}
+Dialogue: 0,0:04:04.77,0:04:07.87,Default,,0,0,0,,{\c&HFFF0F5&}I{\c&HFFF0F5&} {\c&HFFE4E1&}told{\c&HFFE4E1&} {\c&HFAFAD2&}you{\c&HFAFAD2&} {\c&HFFFACD&}I{\c&HFFFACD&} was at a funeral !
+Dialogue: 0,0:04:04.77,0:04:07.88,Default-ja,,0,0,0,,{\c&HFFEFD5&}（{\c&HFFEFD5&}{\c&HFFFFF0&}圭一{\c&HFFFFF0&}{\c&HFFF5EE&}）{\c&HFFF5EE&}{\c&HFAEBD7&}\{\c&HFAEBD7&}{\c&HFFFAFA&}N{\c&HFFFAFA&}{\c&HCCFFFF&}だ{\c&HCCFFFF&}から！俺は葬式に行ったの！
+Dialogue: 0,0:04:08.84,0:04:11.44,Default,,0,0,0,,{\c&HFFEFD5&}Hinamizawa{\c&HFFEFD5&} {\c&HFFFFF0&}is{\c&HFFFFF0&} {\c&HFFF5EE&}a{\c&HFFF5EE&} {\c&HFAEBD7&}small{\c&HFAEBD7&} {\c&HFFFAFA&}village{\c&HFFFAFA&} {\c&HCCFFFF&}...{\c&HCCFFFF&}
+Dialogue: 0,0:04:08.84,0:04:13.98,Default-ja,,0,0,0,,{\c&HFFFFFF&}ここ{\c&HFFFFFF&}{\c&HCCFFFF&}雛{\c&HCCFFFF&}{\c&HCCFFCC&}見沢{\c&HCCFFCC&}{\c&HFFFFCC&}は{\c&HFFFFCC&}{\c&HFFCCCC&}小さな{\c&HFFCCCC&}{\c&HFFCCFF&}村{\c&HFFCCFF&}{\c&HCCE5FF&}で{\c&HCCE5FF&}{\c&HFFD8B1&}\{\c&HFFD8B1&}{\c&HCCE0FF&}N{\c&HCCE0FF&}{\c&HFFFFE0&}学校{\c&HFFFFE0&}{\c&HFFF0F5&}どころか{\c&HFFF0F5&}{\c&HFFE4E1&}クラス{\c&HFFE4E1&}も１つしかない
+Dialogue: 0,0:04:11.55,0:04:14.48,Default,,0,0,0,,{\c&HFFFFFF&}...{\c&HFFFFFF&} {\c&HCCFFFF&}so{\c&HCCFFFF&} {\c&HCCFFCC&}it{\c&HCCFFCC&} {\c&HFFFFCC&}only{\c&HFFFFCC&} {\c&HFFCCCC&}has{\c&HFFCCCC&} {\c&HFFCCFF&}\{\c&HFFCCFF&} {\c&HCCE5FF&}None{\c&HCCE5FF&} {\c&HFFD8B1&}school{\c&HFFD8B1&} {\c&HCCE0FF&}with{\c&HCCE0FF&} {\c&HFFFFE0&}one{\c&HFFFFE0&} {\c&HFFF0F5&}class{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
+Dialogue: 0,0:04:14.58,0:04:17.48,Default,,0,0,0,,{\c&HFAFAD2&}The{\c&HFAFAD2&} {\c&HFFFACD&}class{\c&HFFFACD&} {\c&HFFEFD5&}is{\c&HFFEFD5&} {\c&HFFFFF0&}mixed{\c&HFFFFF0&} {\c&HFFF5EE&}\{\c&HFFF5EE&} {\c&HFAEBD7&}Nages{\c&HFAEBD7&} {\c&HFFFAFA&}and{\c&HFFFAFA&} {\c&HCCFFFF&}grades{\c&HCCFFFF&} {\c&HFFFFFF&}.{\c&HFFFFFF&}
+Dialogue: 0,0:04:14.58,0:04:17.49,Default-ja,,0,0,0,,{\c&HFAFAD2&}その{\c&HFAFAD2&}{\c&HFFFACD&}クラス{\c&HFFFACD&}{\c&HFFEFD5&}も{\c&HFFEFD5&}{\c&HFFFFF0&}\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}{\c&HFAEBD7&}年齢{\c&HFAEBD7&}{\c&HFFFAFA&}学年{\c&HFFFAFA&}{\c&HCCFFFF&}バラバラ{\c&HCCFFFF&}{\c&HFFFFFF&}で{\c&HFFFFFF&}
+Dialogue: 0,0:04:17.59,0:04:21.61,Default,,0,0,0,,{\c&HCCFFFF&}It's{\c&HCCFFFF&} {\c&HCCFFCC&}a{\c&HCCFFCC&} {\c&HFFFFCC&}lonely{\c&HFFFFCC&} {\c&HFFCCCC&}village{\c&HFFCCCC&} {\c&HFFCCFF&}with{\c&HFFCCFF&} {\c&HCCE5FF&}a{\c&HCCE5FF&} {\c&HFFD8B1&}total{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}Nof{\c&HFFFFE0&} {\c&HFFF0F5&}about{\c&HFFF0F5&} {\c&HFFE4E1&}fifteen{\c&HFFE4E1&} {\c&HFAFAD2&}students{\c&HFAFAD2&} {\c&HFFFACD&}.{\c&HFFFACD&}
+Dialogue: 0,0:04:17.59,0:04:21.69,Default-ja,,0,0,0,,{\c&HCCFFFF&}全員{\c&HCCFFFF&}{\c&HCCFFCC&}足し{\c&HCCFFCC&}{\c&HFFFFCC&}て{\c&HFFFFCC&}{\c&HFFCCCC&}も{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}{\c&HFFD8B1&}15{\c&HFFD8B1&}{\c&HCCE0FF&}人{\c&HCCE0FF&}{\c&HFFFFE0&}いる{\c&HFFFFE0&}{\c&HFFF0F5&}か{\c&HFFF0F5&}{\c&HFFE4E1&}どう{\c&HFFE4E1&}{\c&HFAFAD2&}か{\c&HFAFAD2&}{\c&HFFFACD&}という{\c&HFFFACD&}寒村ぶりだ
+Dialogue: 0,0:04:22.16,0:04:23.69,Default-ja,,0,0,0,,{\c&HFFEFD5&}先生{\c&HFFEFD5&}{\c&HFFFFF0&}も{\c&HFFFFF0&}{\c&HFFF5EE&}１{\c&HFFF5EE&}{\c&HFAEBD7&}人{\c&HFAEBD7&}
+Dialogue: 0,0:04:22.29,0:04:23.72,Default,,0,0,0,,{\c&HFFEFD5&}There's{\c&HFFEFD5&} {\c&HFFFFF0&}one{\c&HFFFFF0&} {\c&HFFF5EE&}teacher{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:04:23.79,0:04:27.00,Default-ja,,0,0,0,,{\c&HFFFAFA&}学年{\c&HFFFAFA&}{\c&HCCFFFF&}が{\c&HCCFFFF&}{\c&HFFFFFF&}違う{\c&HFFFFFF&}{\c&HCCFFFF&}ごと{\c&HCCFFFF&}{\c&HCCFFCC&}に{\c&HCCFFCC&}{\c&HFFFFCC&}違う{\c&HFFFFCC&}{\c&HFFCCCC&}こと{\c&HFFCCCC&}{\c&HFFCCFF&}を{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}教え{\c&HCCE0FF&}{\c&HFFFFE0&}なけれ{\c&HFFFFE0&}{\c&HFFF0F5&}ば{\c&HFFF0F5&}{\c&HFFE4E1&}いけ{\c&HFFE4E1&}ないのだから―
+Dialogue: 0,0:04:23.83,0:04:28.85,Default,,0,0,0,,{\c&HFFFAFA&}It{\c&HFFFAFA&} {\c&HCCFFFF&}must{\c&HCCFFFF&} {\c&HFFFFFF&}be{\c&HFFFFFF&} {\c&HCCFFFF&}hard{\c&HCCFFFF&} {\c&HCCFFCC&}to{\c&HCCFFCC&} {\c&HFFFFCC&}teach{\c&HFFFFCC&} {\c&HFFCCCC&}different{\c&HFFCCCC&} {\c&HFFCCFF&}\{\c&HFFCCFF&} {\c&HCCE5FF&}Nthings{\c&HCCE5FF&} {\c&HFFD8B1&}to{\c&HFFD8B1&} {\c&HCCE0FF&}each{\c&HCCE0FF&} {\c&HFFFFE0&}grade{\c&HFFFFE0&} {\c&HFFF0F5&}level{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
 Dialogue: 0,0:04:27.10,0:04:28.43,Default-ja,,0,0,0,,大変だ
-Dialogue: 0,0:04:29.16,0:04:34.07,Default-ja,,0,0,0,,時には 俺が先生に代わって\Nレナや魅音の勉強を見るハメになる
-Dialogue: 0,0:04:29.30,0:04:34.60,Default,,0,0,0,,I sometimes end up teaching\NRena and Mion in her place.
-Dialogue: 0,0:04:39.04,0:04:43.68,Default-ja,,0,0,0,,（ﾚﾅ）圭一君は お勉強教えるの\Nうまいね　分かりやすいよ
-Dialogue: 0,0:04:39.07,0:04:43.60,Default,,0,0,0,,You're good at teaching.\NIt's easy to understand.
-Dialogue: 0,0:04:43.95,0:04:47.31,Default,,0,0,0,,When I start teaching,\NI lose my confidence...
-Dialogue: 0,0:04:43.98,0:04:47.02,Default-ja,,0,0,0,,（圭一）\N教える端から自信がなくなるよ
-Dialogue: 0,0:04:47.42,0:04:50.51,Default,,0,0,0,,...since I realize how little I know.
-Dialogue: 0,0:04:47.45,0:04:50.49,Default-ja,,0,0,0,,自分の理解の浅さが分かるからな…
-Dialogue: 0,0:04:50.59,0:04:51.75,Default-ja,,0,0,0,,（魅音）人に教えるには―
-Dialogue: 0,0:04:50.62,0:04:55.08,Default,,0,0,0,,They say you need to know it\Nthree times better to teach it.
+Dialogue: 0,0:04:29.16,0:04:34.07,Default-ja,,0,0,0,,{\c&HFAFAD2&}時には{\c&HFAFAD2&}{\c&HFFFACD&}俺{\c&HFFFACD&}{\c&HFFEFD5&}が{\c&HFFEFD5&}{\c&HFFFFF0&}先生{\c&HFFFFF0&}{\c&HFFF5EE&}に{\c&HFFF5EE&}{\c&HFAEBD7&}代わっ{\c&HFAEBD7&}{\c&HFFFAFA&}て{\c&HFFFAFA&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}{\c&HCCFFFF&}レナ{\c&HCCFFFF&}{\c&HCCFFCC&}や{\c&HCCFFCC&}{\c&HFFFFCC&}魅{\c&HFFFFCC&}{\c&HFFCCCC&}音{\c&HFFCCCC&}の勉強を見るハメになる
+Dialogue: 0,0:04:29.30,0:04:34.60,Default,,0,0,0,,{\c&HFAFAD2&}I{\c&HFAFAD2&} {\c&HFFFACD&}sometimes{\c&HFFFACD&} {\c&HFFEFD5&}end{\c&HFFEFD5&} {\c&HFFFFF0&}up{\c&HFFFFF0&} {\c&HFFF5EE&}teaching{\c&HFFF5EE&} {\c&HFAEBD7&}\{\c&HFAEBD7&} {\c&HFFFAFA&}NRena{\c&HFFFAFA&} {\c&HCCFFFF&}and{\c&HCCFFFF&} {\c&HFFFFFF&}Mion{\c&HFFFFFF&} {\c&HCCFFFF&}in{\c&HCCFFFF&} {\c&HCCFFCC&}her{\c&HCCFFCC&} {\c&HFFFFCC&}place{\c&HFFFFCC&} {\c&HFFCCCC&}.{\c&HFFCCCC&}
+Dialogue: 0,0:04:39.04,0:04:43.68,Default-ja,,0,0,0,,{\c&HFFCCFF&}（{\c&HFFCCFF&}{\c&HCCE5FF&}ﾚﾅ{\c&HCCE5FF&}{\c&HFFD8B1&}）{\c&HFFD8B1&}{\c&HCCE0FF&}圭一{\c&HCCE0FF&}{\c&HFFFFE0&}君{\c&HFFFFE0&}{\c&HFFF0F5&}は{\c&HFFF0F5&}{\c&HFFE4E1&}お{\c&HFFE4E1&}{\c&HFAFAD2&}勉強{\c&HFAFAD2&}{\c&HFFFACD&}教える{\c&HFFFACD&}{\c&HFFEFD5&}の{\c&HFFEFD5&}\Nうまいね　分かりやすいよ
+Dialogue: 0,0:04:39.07,0:04:43.60,Default,,0,0,0,,{\c&HFFCCFF&}You're{\c&HFFCCFF&} {\c&HCCE5FF&}good{\c&HCCE5FF&} {\c&HFFD8B1&}at{\c&HFFD8B1&} {\c&HCCE0FF&}teaching{\c&HCCE0FF&} {\c&HFFFFE0&}.\{\c&HFFFFE0&} {\c&HFFF0F5&}NIt's{\c&HFFF0F5&} {\c&HFFE4E1&}easy{\c&HFFE4E1&} {\c&HFAFAD2&}to{\c&HFAFAD2&} {\c&HFFFACD&}understand{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:04:43.95,0:04:47.31,Default,,0,0,0,,{\c&HFFFFF0&}When{\c&HFFFFF0&} {\c&HFFF5EE&}I{\c&HFFF5EE&} {\c&HFAEBD7&}start{\c&HFAEBD7&} {\c&HFFFAFA&}teaching{\c&HFFFAFA&} {\c&HCCFFFF&},\{\c&HCCFFFF&} {\c&HFFFFFF&}NI{\c&HFFFFFF&} {\c&HCCFFFF&}lose{\c&HCCFFFF&} {\c&HCCFFCC&}my{\c&HCCFFCC&} {\c&HFFFFCC&}confidence{\c&HFFFFCC&} {\c&HFFCCCC&}...{\c&HFFCCCC&}
+Dialogue: 0,0:04:43.98,0:04:47.02,Default-ja,,0,0,0,,{\c&HFFFFF0&}（{\c&HFFFFF0&}{\c&HFFF5EE&}圭一{\c&HFFF5EE&}{\c&HFAEBD7&}）{\c&HFAEBD7&}{\c&HFFFAFA&}\{\c&HFFFAFA&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HFFFFFF&}教える{\c&HFFFFFF&}{\c&HCCFFFF&}端{\c&HCCFFFF&}{\c&HCCFFCC&}から{\c&HCCFFCC&}{\c&HFFFFCC&}自信{\c&HFFFFCC&}{\c&HFFCCCC&}が{\c&HFFCCCC&}なくなるよ
+Dialogue: 0,0:04:47.42,0:04:50.51,Default,,0,0,0,,{\c&HFFCCFF&}...{\c&HFFCCFF&} {\c&HCCE5FF&}since{\c&HCCE5FF&} {\c&HFFD8B1&}I{\c&HFFD8B1&} {\c&HCCE0FF&}realize{\c&HCCE0FF&} {\c&HFFFFE0&}how{\c&HFFFFE0&} {\c&HFFF0F5&}little{\c&HFFF0F5&} {\c&HFFE4E1&}I{\c&HFFE4E1&} {\c&HFAFAD2&}know{\c&HFAFAD2&} {\c&HFFFACD&}.{\c&HFFFACD&}
+Dialogue: 0,0:04:47.45,0:04:50.49,Default-ja,,0,0,0,,{\c&HFFCCFF&}自分{\c&HFFCCFF&}{\c&HCCE5FF&}の{\c&HCCE5FF&}{\c&HFFD8B1&}理解{\c&HFFD8B1&}{\c&HCCE0FF&}の{\c&HCCE0FF&}{\c&HFFFFE0&}浅{\c&HFFFFE0&}{\c&HFFF0F5&}さ{\c&HFFF0F5&}{\c&HFFE4E1&}が{\c&HFFE4E1&}{\c&HFAFAD2&}分かる{\c&HFAFAD2&}{\c&HFFFACD&}から{\c&HFFFACD&}な…
+Dialogue: 0,0:04:50.59,0:04:51.75,Default-ja,,0,0,0,,{\c&HFFEFD5&}（{\c&HFFEFD5&}{\c&HFFFFF0&}魅{\c&HFFFFF0&}{\c&HFFF5EE&}音{\c&HFFF5EE&}{\c&HFAEBD7&}）{\c&HFAEBD7&}{\c&HFFFAFA&}人{\c&HFFFAFA&}{\c&HCCFFFF&}に{\c&HCCFFFF&}{\c&HFFFFFF&}教える{\c&HFFFFFF&}{\c&HCCFFFF&}に{\c&HCCFFFF&}{\c&HCCFFCC&}は{\c&HCCFFCC&}{\c&HFFFFCC&}―{\c&HFFFFCC&}
+Dialogue: 0,0:04:50.62,0:04:55.08,Default,,0,0,0,,{\c&HFFEFD5&}They{\c&HFFEFD5&} {\c&HFFFFF0&}say{\c&HFFFFF0&} {\c&HFFF5EE&}you{\c&HFFF5EE&} {\c&HFAEBD7&}need{\c&HFAEBD7&} {\c&HFFFAFA&}to{\c&HFFFAFA&} {\c&HCCFFFF&}know{\c&HCCFFFF&} {\c&HFFFFFF&}it{\c&HFFFFFF&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HCCFFCC&}Nthree{\c&HCCFFCC&} {\c&HFFFFCC&}times{\c&HFFFFCC&} better to teach it .
 Dialogue: 0,0:04:51.85,0:04:54.69,Default-ja,,0,0,0,,３倍 理解してなければ\Nならないっていうしね
-Dialogue: 0,0:04:54.82,0:04:58.59,Default-ja,,0,0,0,,…ていうかさ お前\N学年１つ上だろう！
-Dialogue: 0,0:04:55.19,0:05:00.15,Default,,0,0,0,,Actually, you're a grade higher.\NWhy are you learning from me?
-Dialogue: 0,0:04:58.69,0:05:02.00,Default-ja,,0,0,0,,なんで俺に教わってんだ？\N（魅音）細かいことは気にしない
-Dialogue: 0,0:05:00.26,0:05:02.35,Default,,0,0,0,,Don't worry about the details.
-Dialogue: 0,0:05:02.13,0:05:03.87,Default-ja,,0,0,0,,（圭一）アアッ…\N（ﾚﾅ）ねえ 圭一君
-Dialogue: 0,0:05:02.46,0:05:07.49,Default,,0,0,0,,Hey, Keiichi-kun, do you have\Nplans tomorrow? Do you?
+Dialogue: 0,0:04:54.82,0:04:58.59,Default-ja,,0,0,0,,{\c&HFFCCCC&}…{\c&HFFCCCC&}{\c&HFFCCFF&}ていう{\c&HFFCCFF&}{\c&HCCE5FF&}かさ{\c&HCCE5FF&}{\c&HFFD8B1&}お前{\c&HFFD8B1&}{\c&HCCE0FF&}\{\c&HCCE0FF&}{\c&HFFFFE0&}N{\c&HFFFFE0&}{\c&HFFF0F5&}学年{\c&HFFF0F5&}{\c&HFFE4E1&}１つ{\c&HFFE4E1&}{\c&HFAFAD2&}上{\c&HFAFAD2&}{\c&HFFFACD&}だろ{\c&HFFFACD&}{\c&HFFEFD5&}う{\c&HFFEFD5&}{\c&HFFFFF0&}！{\c&HFFFFF0&}
+Dialogue: 0,0:04:55.19,0:05:00.15,Default,,0,0,0,,{\c&HFFCCCC&}Actually{\c&HFFCCCC&} {\c&HFFCCFF&},{\c&HFFCCFF&} {\c&HCCE5FF&}you're{\c&HCCE5FF&} {\c&HFFD8B1&}a{\c&HFFD8B1&} {\c&HCCE0FF&}grade{\c&HCCE0FF&} {\c&HFFFFE0&}higher{\c&HFFFFE0&} {\c&HFFF0F5&}.\{\c&HFFF0F5&} {\c&HFFE4E1&}NWhy{\c&HFFE4E1&} {\c&HFAFAD2&}are{\c&HFAFAD2&} {\c&HFFFACD&}you{\c&HFFFACD&} {\c&HFFEFD5&}learning{\c&HFFEFD5&} {\c&HFFFFF0&}from{\c&HFFFFF0&} me ?
+Dialogue: 0,0:04:58.69,0:05:02.00,Default-ja,,0,0,0,,{\c&HFFF5EE&}なんで{\c&HFFF5EE&}{\c&HFAEBD7&}俺{\c&HFAEBD7&}{\c&HFFFAFA&}に{\c&HFFFAFA&}{\c&HCCFFFF&}教わっ{\c&HCCFFFF&}{\c&HFFFFFF&}て{\c&HFFFFFF&}{\c&HCCFFFF&}ん{\c&HCCFFFF&}だ？\N（魅音）細かいことは気にしない
+Dialogue: 0,0:05:00.26,0:05:02.35,Default,,0,0,0,,{\c&HFFF5EE&}Don't{\c&HFFF5EE&} {\c&HFAEBD7&}worry{\c&HFAEBD7&} {\c&HFFFAFA&}about{\c&HFFFAFA&} {\c&HCCFFFF&}the{\c&HCCFFFF&} {\c&HFFFFFF&}details{\c&HFFFFFF&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:05:02.13,0:05:03.87,Default-ja,,0,0,0,,{\c&HCCFFCC&}（{\c&HCCFFCC&}{\c&HFFFFCC&}圭一{\c&HFFFFCC&}{\c&HFFCCCC&}）{\c&HFFCCCC&}{\c&HFFCCFF&}アアッ{\c&HFFCCFF&}{\c&HCCE5FF&}…{\c&HCCE5FF&}{\c&HFFD8B1&}\{\c&HFFD8B1&}{\c&HCCE0FF&}N{\c&HCCE0FF&}{\c&HFFFFE0&}（{\c&HFFFFE0&}{\c&HFFF0F5&}ﾚﾅ{\c&HFFF0F5&}{\c&HFFE4E1&}）{\c&HFFE4E1&}{\c&HFAFAD2&}ねえ{\c&HFAFAD2&}{\c&HFFFACD&}圭一{\c&HFFFACD&}{\c&HFFEFD5&}君{\c&HFFEFD5&}
+Dialogue: 0,0:05:02.46,0:05:07.49,Default,,0,0,0,,{\c&HCCFFCC&}Hey{\c&HCCFFCC&} {\c&HFFFFCC&},{\c&HFFFFCC&} {\c&HFFCCCC&}Keiichi{\c&HFFCCCC&} {\c&HFFCCFF&}-{\c&HFFCCFF&} {\c&HCCE5FF&}kun{\c&HCCE5FF&} {\c&HFFD8B1&},{\c&HFFD8B1&} {\c&HCCE0FF&}do{\c&HCCE0FF&} {\c&HFFFFE0&}you{\c&HFFFFE0&} {\c&HFFF0F5&}have{\c&HFFF0F5&} {\c&HFFE4E1&}\{\c&HFFE4E1&} {\c&HFAFAD2&}Nplans{\c&HFAFAD2&} {\c&HFFFACD&}tomorrow{\c&HFFFACD&} {\c&HFFEFD5&}?{\c&HFFEFD5&} Do you ?
 Dialogue: 0,0:05:03.97,0:05:07.60,Default-ja,,0,0,0,,あしたはさ\N何か予定とかあるかな？ かな？
-Dialogue: 0,0:05:07.74,0:05:10.01,Default-ja,,0,0,0,,えっ？\N（魅音）圭ちゃんさ…
-Dialogue: 0,0:05:08.80,0:05:13.67,Default,,0,0,0,,You still can't find your way\Naround Hinamizawa alone, right?
-Dialogue: 0,0:05:10.11,0:05:12.97,Default-ja,,0,0,0,,まだ この雛見沢\N１人じゃ回れないでしょう？
-Dialogue: 0,0:05:13.78,0:05:15.14,Default,,0,0,0,,I guess.
-Dialogue: 0,0:05:13.78,0:05:19.18,Default-ja,,0,0,0,,そうだな　街へ行くのと\N学校へ行く以外は まだ自信ないな
-Dialogue: 0,0:05:15.24,0:05:19.41,Default,,0,0,0,,I'm still not sure how to get to\Nplaces besides school and town.
-Dialogue: 0,0:05:19.51,0:05:20.67,Default,,0,0,0,,Right, right.
-Dialogue: 0,0:05:19.58,0:05:24.45,Default-ja,,0,0,0,,そうそう それでね\Nあしたね 魅ぃちゃんとレナで―
+Dialogue: 0,0:05:07.74,0:05:10.01,Default-ja,,0,0,0,,{\c&HFFFFF0&}えっ{\c&HFFFFF0&}{\c&HFFF5EE&}？{\c&HFFF5EE&}{\c&HFAEBD7&}\{\c&HFAEBD7&}{\c&HFFFAFA&}N{\c&HFFFAFA&}{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HFFFFFF&}魅{\c&HFFFFFF&}{\c&HCCFFFF&}音{\c&HCCFFFF&}{\c&HCCFFCC&}）{\c&HCCFFCC&}{\c&HFFFFCC&}圭{\c&HFFFFCC&}{\c&HFFCCCC&}ちゃん{\c&HFFCCCC&}{\c&HFFCCFF&}さ{\c&HFFCCFF&}{\c&HCCE5FF&}…{\c&HCCE5FF&}
+Dialogue: 0,0:05:08.80,0:05:13.67,Default,,0,0,0,,{\c&HFFFFF0&}You{\c&HFFFFF0&} {\c&HFFF5EE&}still{\c&HFFF5EE&} {\c&HFAEBD7&}can't{\c&HFAEBD7&} {\c&HFFFAFA&}find{\c&HFFFAFA&} {\c&HCCFFFF&}your{\c&HCCFFFF&} {\c&HFFFFFF&}way{\c&HFFFFFF&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HCCFFCC&}Naround{\c&HCCFFCC&} {\c&HFFFFCC&}Hinamizawa{\c&HFFFFCC&} {\c&HFFCCCC&}alone{\c&HFFCCCC&} {\c&HFFCCFF&},{\c&HFFCCFF&} {\c&HCCE5FF&}right{\c&HCCE5FF&} ?
+Dialogue: 0,0:05:10.11,0:05:12.97,Default-ja,,0,0,0,,{\c&HFFD8B1&}まだ{\c&HFFD8B1&}{\c&HCCE0FF&}この{\c&HCCE0FF&}{\c&HFFFFE0&}雛{\c&HFFFFE0&}見沢\N１人じゃ回れないでしょう？
+Dialogue: 0,0:05:13.78,0:05:15.14,Default,,0,0,0,,{\c&HFFD8B1&}I{\c&HFFD8B1&} {\c&HCCE0FF&}guess{\c&HCCE0FF&} {\c&HFFFFE0&}.{\c&HFFFFE0&}
+Dialogue: 0,0:05:13.78,0:05:19.18,Default-ja,,0,0,0,,{\c&HFFF0F5&}そう{\c&HFFF0F5&}{\c&HFFE4E1&}だ{\c&HFFE4E1&}{\c&HFAFAD2&}な{\c&HFAFAD2&}{\c&HFFFACD&}　{\c&HFFFACD&}{\c&HFFEFD5&}街{\c&HFFEFD5&}{\c&HFFFFF0&}へ{\c&HFFFFF0&}{\c&HFFF5EE&}行く{\c&HFFF5EE&}{\c&HFAEBD7&}の{\c&HFAEBD7&}{\c&HFFFAFA&}と{\c&HFFFAFA&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}{\c&HCCFFFF&}学校{\c&HCCFFFF&}{\c&HCCFFCC&}へ{\c&HCCFFCC&}{\c&HFFFFCC&}行く{\c&HFFFFCC&}{\c&HFFCCCC&}以外{\c&HFFCCCC&}はまだ自信ないな
+Dialogue: 0,0:05:15.24,0:05:19.41,Default,,0,0,0,,{\c&HFFF0F5&}I'm{\c&HFFF0F5&} {\c&HFFE4E1&}still{\c&HFFE4E1&} {\c&HFAFAD2&}not{\c&HFAFAD2&} {\c&HFFFACD&}sure{\c&HFFFACD&} {\c&HFFEFD5&}how{\c&HFFEFD5&} {\c&HFFFFF0&}to{\c&HFFFFF0&} {\c&HFFF5EE&}get{\c&HFFF5EE&} {\c&HFAEBD7&}to{\c&HFAEBD7&} {\c&HFFFAFA&}\{\c&HFFFAFA&} {\c&HCCFFFF&}Nplaces{\c&HCCFFFF&} {\c&HFFFFFF&}besides{\c&HFFFFFF&} {\c&HCCFFFF&}school{\c&HCCFFFF&} {\c&HCCFFCC&}and{\c&HCCFFCC&} {\c&HFFFFCC&}town{\c&HFFFFCC&} {\c&HFFCCCC&}.{\c&HFFCCCC&}
+Dialogue: 0,0:05:19.51,0:05:20.67,Default,,0,0,0,,{\c&HFFCCFF&}Right{\c&HFFCCFF&} {\c&HCCE5FF&},{\c&HCCE5FF&} {\c&HFFD8B1&}right{\c&HFFD8B1&} {\c&HCCE0FF&}.{\c&HCCE0FF&}
+Dialogue: 0,0:05:19.58,0:05:24.45,Default-ja,,0,0,0,,{\c&HFFCCFF&}そう{\c&HFFCCFF&}{\c&HCCE5FF&}そう{\c&HCCE5FF&}{\c&HFFD8B1&}それで{\c&HFFD8B1&}{\c&HCCE0FF&}ね{\c&HCCE0FF&}\Nあしたね魅ぃちゃんとレナで―
 Dialogue: 0,0:05:20.78,0:05:24.45,Default,,0,0,0,,So for tomorrow, Mi-chan and I...
-Dialogue: 0,0:05:24.55,0:05:30.05,Default,,0,0,0,,...want to show you around\NHinamizawa while taking a walk.
-Dialogue: 0,0:05:24.55,0:05:26.76,Default-ja,,0,0,0,,お散歩しながら\N圭一君に雛見沢を―
+Dialogue: 0,0:05:24.55,0:05:30.05,Default,,0,0,0,,{\c&HFFFFE0&}...{\c&HFFFFE0&} {\c&HFFF0F5&}want{\c&HFFF0F5&} {\c&HFFE4E1&}to{\c&HFFE4E1&} {\c&HFAFAD2&}show{\c&HFAFAD2&} {\c&HFFFACD&}you{\c&HFFFACD&} {\c&HFFEFD5&}around{\c&HFFEFD5&} {\c&HFFFFF0&}\{\c&HFFFFF0&} {\c&HFFF5EE&}NHinamizawa{\c&HFFF5EE&} {\c&HFAEBD7&}while{\c&HFAEBD7&} {\c&HFFFAFA&}taking{\c&HFFFAFA&} {\c&HCCFFFF&}a{\c&HCCFFFF&} {\c&HFFFFFF&}walk{\c&HFFFFFF&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:05:24.55,0:05:26.76,Default-ja,,0,0,0,,{\c&HFFFFE0&}お{\c&HFFFFE0&}{\c&HFFF0F5&}散歩{\c&HFFF0F5&}{\c&HFFE4E1&}し{\c&HFFE4E1&}{\c&HFAFAD2&}ながら{\c&HFAFAD2&}{\c&HFFFACD&}\{\c&HFFFACD&}{\c&HFFEFD5&}N{\c&HFFEFD5&}{\c&HFFFFF0&}圭一{\c&HFFFFF0&}{\c&HFFF5EE&}君{\c&HFFF5EE&}{\c&HFAEBD7&}に{\c&HFAEBD7&}{\c&HFFFAFA&}雛{\c&HFFFAFA&}{\c&HCCFFFF&}見沢{\c&HCCFFFF&}{\c&HFFFFFF&}を{\c&HFFFFFF&}{\c&HCCFFFF&}―{\c&HCCFFFF&}
 Dialogue: 0,0:05:26.86,0:05:29.96,Default-ja,,0,0,0,,案内してあげようよってことに\Nなって
-Dialogue: 0,0:05:30.06,0:05:33.03,Default-ja,,0,0,0,,レナ お弁当 作っていくから\Nどうかな？
-Dialogue: 0,0:05:30.16,0:05:33.13,Default,,0,0,0,,I'll make boxed lunches.\NInterested?
-Dialogue: 0,0:05:33.13,0:05:34.56,Default-ja,,0,0,0,,もちろん行くでしょう？
-Dialogue: 0,0:05:33.23,0:05:34.69,Default,,0,0,0,,You'll come, right?
-Dialogue: 0,0:05:34.70,0:05:35.93,Default-ja,,0,0,0,,暇ならな
-Dialogue: 0,0:05:34.80,0:05:35.99,Default,,0,0,0,,If I'm free.
-Dialogue: 0,0:05:36.03,0:05:39.84,Default-ja,,0,0,0,,何よ その態度！\N女の子が誘ってんじゃん！
-Dialogue: 0,0:05:36.10,0:05:39.86,Default,,0,0,0,,What's with that attitude?\NA girl's asking you out!
-Dialogue: 0,0:05:39.94,0:05:41.80,Default-ja,,0,0,0,,暇ならな\N（魅音）なっ…
-Dialogue: 0,0:05:39.97,0:05:41.43,Default,,0,0,0,,If I'm free.
-Dialogue: 0,0:05:43.00,0:05:46.57,Default,,0,0,0,,Keiichi-kun, aren't you free?\NAren't you?
-Dialogue: 0,0:05:43.07,0:05:46.68,Default-ja,,0,0,0,,圭一君 暇じゃないのかな？ かな？
-Dialogue: 0,0:05:46.74,0:05:47.87,Default,,0,0,0,,I'm free.
-Dialogue: 0,0:05:46.81,0:05:48.18,Default-ja,,0,0,0,,暇だ\N（魅音）なっ！
-Dialogue: 0,0:05:48.51,0:05:49.64,Default,,0,0,0,,I'm glad!
-Dialogue: 0,0:05:48.61,0:05:49.78,Default-ja,,0,0,0,,良かった
-Dialogue: 0,0:05:49.84,0:05:54.28,Default,,0,0,0,,Hey, I see quite a difference\Nin how you treat us here.
-Dialogue: 0,0:05:49.88,0:05:54.08,Default-ja,,0,0,0,,おうおう 魅音さんとレナさんじゃ\N随分と温度差がありますじゃん！
-Dialogue: 0,0:05:54.25,0:05:55.15,Default-ja,,0,0,0,,ベーッ！\N（魅音）ムカッ！
-Dialogue: 0,0:05:55.85,0:05:58.58,Default,,0,0,0,,Rena, let's go out\Nalone tomorrow.
-Dialogue: 0,0:05:55.85,0:05:58.62,Default-ja,,0,0,0,,（圭一）レナ\Nあしたは２人きりで出かけような
-Dialogue: 0,0:05:58.69,0:06:00.45,Default,,0,0,0,,If that's what you want.
-Dialogue: 0,0:05:58.72,0:06:00.52,Default-ja,,0,0,0,,（ﾚﾅ）圭一君が それでいいなら
-Dialogue: 0,0:06:00.56,0:06:04.65,Default,,0,0,0,,Hey, I was the one\Nwho suggested the tour!
-Dialogue: 0,0:06:00.62,0:06:04.13,Default-ja,,0,0,0,,（魅音）ちょっと 案内しようって\N提案したのは あたし！
-Dialogue: 0,0:06:07.76,0:06:10.73,Default,,0,0,0,,This is called Furude Shrine.
-Dialogue: 0,0:06:07.76,0:06:10.77,Default-ja,,0,0,0,,（ﾚﾅ）\Nここはね 古手(ふるで)神社っていうの
-Dialogue: 0,0:06:10.83,0:06:14.56,Default,,0,0,0,,This place probably\Nhas the best view.
-Dialogue: 0,0:06:10.87,0:06:13.64,Default-ja,,0,0,0,,多分\N見晴らしが いちばんいい所かな
-Dialogue: 0,0:06:14.67,0:06:18.90,Default,,0,0,0,,During the next break,\Nthere's going to be a festival here.
+Dialogue: 0,0:05:30.06,0:05:33.03,Default-ja,,0,0,0,,{\c&HCCFFCC&}レナ{\c&HCCFFCC&}{\c&HFFFFCC&}お{\c&HFFFFCC&}{\c&HFFCCCC&}弁当{\c&HFFCCCC&}{\c&HFFCCFF&}作っ{\c&HFFCCFF&}{\c&HCCE5FF&}て{\c&HCCE5FF&}{\c&HFFD8B1&}いく{\c&HFFD8B1&}{\c&HCCE0FF&}から{\c&HCCE0FF&}\Nどうかな？
+Dialogue: 0,0:05:30.16,0:05:33.13,Default,,0,0,0,,{\c&HCCFFCC&}I'll{\c&HCCFFCC&} {\c&HFFFFCC&}make{\c&HFFFFCC&} {\c&HFFCCCC&}boxed{\c&HFFCCCC&} {\c&HFFCCFF&}lunches{\c&HFFCCFF&} {\c&HCCE5FF&}.\{\c&HCCE5FF&} {\c&HFFD8B1&}NInterested{\c&HFFD8B1&} {\c&HCCE0FF&}?{\c&HCCE0FF&}
+Dialogue: 0,0:05:33.13,0:05:34.56,Default-ja,,0,0,0,,{\c&HFFFFE0&}もちろん{\c&HFFFFE0&}{\c&HFFF0F5&}行く{\c&HFFF0F5&}{\c&HFFE4E1&}でしょ{\c&HFFE4E1&}{\c&HFAFAD2&}う{\c&HFAFAD2&}{\c&HFFFACD&}？{\c&HFFFACD&}
+Dialogue: 0,0:05:33.23,0:05:34.69,Default,,0,0,0,,{\c&HFFFFE0&}You'll{\c&HFFFFE0&} {\c&HFFF0F5&}come{\c&HFFF0F5&} {\c&HFFE4E1&},{\c&HFFE4E1&} {\c&HFAFAD2&}right{\c&HFAFAD2&} {\c&HFFFACD&}?{\c&HFFFACD&}
+Dialogue: 0,0:05:34.70,0:05:35.93,Default-ja,,0,0,0,,{\c&HFFEFD5&}暇{\c&HFFEFD5&}{\c&HFFFFF0&}なら{\c&HFFFFF0&}{\c&HFFF5EE&}な{\c&HFFF5EE&}
+Dialogue: 0,0:05:34.80,0:05:35.99,Default,,0,0,0,,{\c&HFFEFD5&}If{\c&HFFEFD5&} {\c&HFFFFF0&}I'm{\c&HFFFFF0&} {\c&HFFF5EE&}free{\c&HFFF5EE&} .
+Dialogue: 0,0:05:36.03,0:05:39.84,Default-ja,,0,0,0,,{\c&HFAEBD7&}何{\c&HFAEBD7&}{\c&HFFFAFA&}よ{\c&HFFFAFA&}{\c&HCCFFFF&}その{\c&HCCFFFF&}{\c&HFFFFFF&}態度{\c&HFFFFFF&}{\c&HCCFFFF&}！\{\c&HCCFFFF&}{\c&HCCFFCC&}N{\c&HCCFFCC&}{\c&HFFFFCC&}女の子{\c&HFFFFCC&}{\c&HFFCCCC&}が{\c&HFFCCCC&}{\c&HFFCCFF&}誘っ{\c&HFFCCFF&}{\c&HCCE5FF&}て{\c&HCCE5FF&}{\c&HFFD8B1&}ん{\c&HFFD8B1&}じゃん！
+Dialogue: 0,0:05:36.10,0:05:39.86,Default,,0,0,0,,{\c&HFAEBD7&}What's{\c&HFAEBD7&} {\c&HFFFAFA&}with{\c&HFFFAFA&} {\c&HCCFFFF&}that{\c&HCCFFFF&} {\c&HFFFFFF&}attitude{\c&HFFFFFF&} {\c&HCCFFFF&}?\{\c&HCCFFFF&} {\c&HCCFFCC&}NA{\c&HCCFFCC&} {\c&HFFFFCC&}girl's{\c&HFFFFCC&} {\c&HFFCCCC&}asking{\c&HFFCCCC&} {\c&HFFCCFF&}you{\c&HFFCCFF&} {\c&HCCE5FF&}out{\c&HCCE5FF&} {\c&HFFD8B1&}!{\c&HFFD8B1&}
+Dialogue: 0,0:05:39.94,0:05:41.80,Default-ja,,0,0,0,,{\c&HCCE0FF&}暇{\c&HCCE0FF&}{\c&HFFFFE0&}なら{\c&HFFFFE0&}{\c&HFFF0F5&}な{\c&HFFF0F5&}{\c&HFFE4E1&}\{\c&HFFE4E1&}N（魅音）なっ…
+Dialogue: 0,0:05:39.97,0:05:41.43,Default,,0,0,0,,{\c&HCCE0FF&}If{\c&HCCE0FF&} {\c&HFFFFE0&}I'm{\c&HFFFFE0&} {\c&HFFF0F5&}free{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
+Dialogue: 0,0:05:43.00,0:05:46.57,Default,,0,0,0,,{\c&HFAFAD2&}Keiichi{\c&HFAFAD2&} {\c&HFFFACD&}-{\c&HFFFACD&} {\c&HFFEFD5&}kun{\c&HFFEFD5&} {\c&HFFFFF0&},{\c&HFFFFF0&} {\c&HFFF5EE&}aren't{\c&HFFF5EE&} {\c&HFAEBD7&}you{\c&HFAEBD7&} {\c&HFFFAFA&}free{\c&HFFFAFA&} {\c&HCCFFFF&}?\{\c&HCCFFFF&} {\c&HFFFFFF&}NAren't{\c&HFFFFFF&} {\c&HCCFFFF&}you{\c&HCCFFFF&} {\c&HCCFFCC&}?{\c&HCCFFCC&}
+Dialogue: 0,0:05:43.07,0:05:46.68,Default-ja,,0,0,0,,{\c&HFAFAD2&}圭一{\c&HFAFAD2&}{\c&HFFFACD&}君{\c&HFFFACD&}{\c&HFFEFD5&}暇{\c&HFFEFD5&}{\c&HFFFFF0&}じゃ{\c&HFFFFF0&}{\c&HFFF5EE&}ない{\c&HFFF5EE&}{\c&HFAEBD7&}の{\c&HFAEBD7&}{\c&HFFFAFA&}か{\c&HFFFAFA&}{\c&HCCFFFF&}な{\c&HCCFFFF&}{\c&HFFFFFF&}？{\c&HFFFFFF&}{\c&HCCFFFF&}か{\c&HCCFFFF&}{\c&HCCFFCC&}な{\c&HCCFFCC&}？
+Dialogue: 0,0:05:46.74,0:05:47.87,Default,,0,0,0,,{\c&HFFFFCC&}I'm{\c&HFFFFCC&} {\c&HFFCCCC&}free{\c&HFFCCCC&} {\c&HFFCCFF&}.{\c&HFFCCFF&}
+Dialogue: 0,0:05:46.81,0:05:48.18,Default-ja,,0,0,0,,{\c&HFFFFCC&}暇{\c&HFFFFCC&}{\c&HFFCCCC&}だ{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}N（魅音）なっ！
+Dialogue: 0,0:05:48.51,0:05:49.64,Default,,0,0,0,,{\c&HCCE5FF&}I'm{\c&HCCE5FF&} {\c&HFFD8B1&}glad{\c&HFFD8B1&} !
+Dialogue: 0,0:05:48.61,0:05:49.78,Default-ja,,0,0,0,,{\c&HCCE5FF&}良かっ{\c&HCCE5FF&}{\c&HFFD8B1&}た{\c&HFFD8B1&}
+Dialogue: 0,0:05:49.84,0:05:54.28,Default,,0,0,0,,{\c&HCCE0FF&}Hey{\c&HCCE0FF&} {\c&HFFFFE0&},{\c&HFFFFE0&} {\c&HFFF0F5&}I{\c&HFFF0F5&} {\c&HFFE4E1&}see{\c&HFFE4E1&} {\c&HFAFAD2&}quite{\c&HFAFAD2&} {\c&HFFFACD&}a{\c&HFFFACD&} {\c&HFFEFD5&}difference{\c&HFFEFD5&} {\c&HFFFFF0&}\{\c&HFFFFF0&} {\c&HFFF5EE&}Nin{\c&HFFF5EE&} {\c&HFAEBD7&}how{\c&HFAEBD7&} {\c&HFFFAFA&}you{\c&HFFFAFA&} {\c&HCCFFFF&}treat{\c&HCCFFFF&} {\c&HFFFFFF&}us{\c&HFFFFFF&} {\c&HCCFFFF&}here{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:05:49.88,0:05:54.08,Default-ja,,0,0,0,,{\c&HCCE0FF&}おうおう{\c&HCCE0FF&}{\c&HFFFFE0&}魅{\c&HFFFFE0&}{\c&HFFF0F5&}音{\c&HFFF0F5&}{\c&HFFE4E1&}さん{\c&HFFE4E1&}{\c&HFAFAD2&}と{\c&HFAFAD2&}{\c&HFFFACD&}レナ{\c&HFFFACD&}{\c&HFFEFD5&}さん{\c&HFFEFD5&}{\c&HFFFFF0&}じゃ{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}{\c&HFAEBD7&}N{\c&HFAEBD7&}{\c&HFFFAFA&}随分{\c&HFFFAFA&}{\c&HCCFFFF&}と{\c&HCCFFFF&}{\c&HFFFFFF&}温度{\c&HFFFFFF&}{\c&HCCFFFF&}差{\c&HCCFFFF&}{\c&HCCFFCC&}が{\c&HCCFFCC&}ありますじゃん！
+Dialogue: 0,0:05:54.25,0:05:55.15,Default-ja,,0,0,0,,{\c&HFFFFCC&}ベーッ{\c&HFFFFCC&}{\c&HFFCCCC&}！\{\c&HFFCCCC&}{\c&HFFCCFF&}N{\c&HFFCCFF&}{\c&HCCE5FF&}（{\c&HCCE5FF&}{\c&HFFD8B1&}魅{\c&HFFD8B1&}{\c&HCCE0FF&}音{\c&HCCE0FF&}{\c&HFFFFE0&}）{\c&HFFFFE0&}{\c&HFFF0F5&}ムカッ{\c&HFFF0F5&}{\c&HFFE4E1&}！{\c&HFFE4E1&}
+Dialogue: 0,0:05:55.85,0:05:58.58,Default,,0,0,0,,{\c&HFFFFCC&}Rena{\c&HFFFFCC&} {\c&HFFCCCC&},{\c&HFFCCCC&} {\c&HFFCCFF&}let's{\c&HFFCCFF&} {\c&HCCE5FF&}go{\c&HCCE5FF&} {\c&HFFD8B1&}out{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}Nalone{\c&HFFFFE0&} {\c&HFFF0F5&}tomorrow{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
+Dialogue: 0,0:05:55.85,0:05:58.62,Default-ja,,0,0,0,,{\c&HFAFAD2&}（{\c&HFAFAD2&}{\c&HFFFACD&}圭一{\c&HFFFACD&}{\c&HFFEFD5&}）{\c&HFFEFD5&}{\c&HFFFFF0&}レナ{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}{\c&HFAEBD7&}N{\c&HFAEBD7&}あしたは２人きりで出かけような
+Dialogue: 0,0:05:58.69,0:06:00.45,Default,,0,0,0,,{\c&HFAFAD2&}If{\c&HFAFAD2&} {\c&HFFFACD&}that's{\c&HFFFACD&} {\c&HFFEFD5&}what{\c&HFFEFD5&} {\c&HFFFFF0&}you{\c&HFFFFF0&} {\c&HFFF5EE&}want{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:05:58.72,0:06:00.52,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}ﾚﾅ{\c&HCCFFFF&}{\c&HFFFFFF&}）{\c&HFFFFFF&}{\c&HCCFFFF&}圭一{\c&HCCFFFF&}{\c&HCCFFCC&}君{\c&HCCFFCC&}{\c&HFFFFCC&}が{\c&HFFFFCC&}{\c&HFFCCCC&}それ{\c&HFFCCCC&}{\c&HFFCCFF&}で{\c&HFFCCFF&}{\c&HCCE5FF&}いい{\c&HCCE5FF&}{\c&HFFD8B1&}なら{\c&HFFD8B1&}
+Dialogue: 0,0:06:00.56,0:06:04.65,Default,,0,0,0,,{\c&HFFFAFA&}Hey{\c&HFFFAFA&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HFFFFFF&}I{\c&HFFFFFF&} {\c&HCCFFFF&}was{\c&HCCFFFF&} {\c&HCCFFCC&}the{\c&HCCFFCC&} {\c&HFFFFCC&}one{\c&HFFFFCC&} {\c&HFFCCCC&}\{\c&HFFCCCC&} {\c&HFFCCFF&}Nwho{\c&HFFCCFF&} {\c&HCCE5FF&}suggested{\c&HCCE5FF&} {\c&HFFD8B1&}the{\c&HFFD8B1&} tour !
+Dialogue: 0,0:06:00.62,0:06:04.13,Default-ja,,0,0,0,,{\c&HCCE0FF&}（{\c&HCCE0FF&}{\c&HFFFFE0&}魅{\c&HFFFFE0&}{\c&HFFF0F5&}音{\c&HFFF0F5&}{\c&HFFE4E1&}）{\c&HFFE4E1&}{\c&HFAFAD2&}ちょっと{\c&HFAFAD2&}{\c&HFFFACD&}案内{\c&HFFFACD&}しようって\N提案したのはあたし！
+Dialogue: 0,0:06:07.76,0:06:10.73,Default,,0,0,0,,{\c&HCCE0FF&}This{\c&HCCE0FF&} {\c&HFFFFE0&}is{\c&HFFFFE0&} {\c&HFFF0F5&}called{\c&HFFF0F5&} {\c&HFFE4E1&}Furude{\c&HFFE4E1&} {\c&HFAFAD2&}Shrine{\c&HFAFAD2&} {\c&HFFFACD&}.{\c&HFFFACD&}
+Dialogue: 0,0:06:07.76,0:06:10.77,Default-ja,,0,0,0,,{\c&HFFEFD5&}（{\c&HFFEFD5&}{\c&HFFFFF0&}ﾚﾅ{\c&HFFFFF0&}{\c&HFFF5EE&}）\{\c&HFFF5EE&}{\c&HFAEBD7&}N{\c&HFAEBD7&}{\c&HFFFAFA&}ここ{\c&HFFFAFA&}{\c&HCCFFFF&}はね{\c&HCCFFFF&}{\c&HFFFFFF&}古手{\c&HFFFFFF&}{\c&HCCFFFF&}({\c&HCCFFFF&}{\c&HCCFFCC&}ふる{\c&HCCFFCC&}で)神社っていうの
+Dialogue: 0,0:06:10.83,0:06:14.56,Default,,0,0,0,,{\c&HFFEFD5&}This{\c&HFFEFD5&} {\c&HFFFFF0&}place{\c&HFFFFF0&} {\c&HFFF5EE&}probably{\c&HFFF5EE&} {\c&HFAEBD7&}\{\c&HFAEBD7&} {\c&HFFFAFA&}Nhas{\c&HFFFAFA&} {\c&HCCFFFF&}the{\c&HCCFFFF&} {\c&HFFFFFF&}best{\c&HFFFFFF&} {\c&HCCFFFF&}view{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:06:10.87,0:06:13.64,Default-ja,,0,0,0,,{\c&HFFFFCC&}多分{\c&HFFFFCC&}{\c&HFFCCCC&}\{\c&HFFCCCC&}{\c&HFFCCFF&}N{\c&HFFCCFF&}{\c&HCCE5FF&}見晴らし{\c&HCCE5FF&}{\c&HFFD8B1&}が{\c&HFFD8B1&}{\c&HCCE0FF&}いちばん{\c&HCCE0FF&}{\c&HFFFFE0&}いい{\c&HFFFFE0&}{\c&HFFF0F5&}所{\c&HFFF0F5&}{\c&HFFE4E1&}か{\c&HFFE4E1&}{\c&HFAFAD2&}な{\c&HFAFAD2&}
+Dialogue: 0,0:06:14.67,0:06:18.90,Default,,0,0,0,,{\c&HFFFFCC&}During{\c&HFFFFCC&} {\c&HFFCCCC&}the{\c&HFFCCCC&} {\c&HFFCCFF&}next{\c&HFFCCFF&} {\c&HCCE5FF&}break{\c&HCCE5FF&} {\c&HFFD8B1&},\{\c&HFFD8B1&} {\c&HCCE0FF&}Nthere's{\c&HCCE0FF&} {\c&HFFFFE0&}going{\c&HFFFFE0&} {\c&HFFF0F5&}to{\c&HFFF0F5&} {\c&HFFE4E1&}be{\c&HFFE4E1&} {\c&HFAFAD2&}a{\c&HFAFAD2&} festival here .
 Dialogue: 0,0:06:14.77,0:06:17.77,Default-ja,,0,0,0,,（魅音）次の休みは\Nここで お祭りがあるからね
 Dialogue: 0,0:06:17.87,0:06:18.94,Default-ja,,0,0,0,,（圭一）ふ～ん…
-Dialogue: 0,0:06:21.24,0:06:22.58,Default-ja,,0,0,0,,じゃじゃ～ん！
-Dialogue: 0,0:06:21.34,0:06:25.90,Default,,0,0,0,,Ta-dah! Rena's deluxe\Nboxed lunches, special version!
+Dialogue: 0,0:06:21.24,0:06:22.58,Default-ja,,0,0,0,,{\c&HFFFACD&}じゃ{\c&HFFFACD&}{\c&HFFEFD5&}じゃ{\c&HFFEFD5&}{\c&HFFFFF0&}～{\c&HFFFFF0&}{\c&HFFF5EE&}ん{\c&HFFF5EE&}{\c&HFAEBD7&}！{\c&HFAEBD7&}
+Dialogue: 0,0:06:21.34,0:06:25.90,Default,,0,0,0,,{\c&HFFFACD&}Ta{\c&HFFFACD&} {\c&HFFEFD5&}-{\c&HFFEFD5&} {\c&HFFFFF0&}dah{\c&HFFFFF0&} {\c&HFFF5EE&}!{\c&HFFF5EE&} {\c&HFAEBD7&}Rena's{\c&HFAEBD7&} deluxe \ Nboxed lunches , special version !
 Dialogue: 0,0:06:22.68,0:06:25.95,Default-ja,,0,0,0,,レナの特製弁当\Nスペシャルバージョンだよ
-Dialogue: 0,0:06:26.08,0:06:28.62,Default-ja,,0,0,0,,う～ん… すごい量だ
-Dialogue: 0,0:06:26.28,0:06:28.51,Default,,0,0,0,,Gee, that's a lot.
-Dialogue: 0,0:06:28.95,0:06:31.09,Default-ja,,0,0,0,,（梨花(りか)）こんにちはです\N（圭一）はぁ？
-Dialogue: 0,0:06:28.98,0:06:30.51,Default,,0,0,0,,Hello.
-Dialogue: 0,0:06:31.19,0:06:32.85,Default-ja,,0,0,0,,（魅音）オッ！ 来た来た
-Dialogue: 0,0:06:31.29,0:06:33.25,Default,,0,0,0,,Oh, there you are.
-Dialogue: 0,0:06:33.26,0:06:35.16,Default-ja,,0,0,0,,（圭一）沙都子(さとこ)に梨花ちゃん？
-Dialogue: 0,0:06:33.35,0:06:35.75,Default,,0,0,0,,Satoko and Rika-chan?
-Dialogue: 0,0:06:35.99,0:06:40.73,Default-ja,,0,0,0,,この２人は 俺のクラスメートの\N北条(ほうじょう)沙都子と古手(ふるで)梨花
-Dialogue: 0,0:06:36.02,0:06:40.69,Default,,0,0,0,,These two are my classmates,\NSatoko Hojo and Rika Furude.
-Dialogue: 0,0:06:40.80,0:06:43.53,Default,,0,0,0,,They're underclassmen of course.
-Dialogue: 0,0:06:40.83,0:06:43.83,Default-ja,,0,0,0,,…とはいっても\Nもちろん学年は下だけど
-Dialogue: 0,0:06:44.67,0:06:47.36,Default,,0,0,0,,What's with all this excitement?
-Dialogue: 0,0:06:44.70,0:06:47.30,Default-ja,,0,0,0,,（沙都子）\Nこれは 一体 何の騒ぎですの？
-Dialogue: 0,0:06:47.74,0:06:49.46,Default,,0,0,0,,Can't you tell?
-Dialogue: 0,0:06:47.74,0:06:49.54,Default-ja,,0,0,0,,（圭一）見りゃ分かるだろう
-Dialogue: 0,0:06:49.57,0:06:52.87,Default,,0,0,0,,We're about to enjoy Rena's\Nhomemade boxed lunches.
-Dialogue: 0,0:06:49.64,0:06:52.81,Default-ja,,0,0,0,,これから\Nレナの手作り弁当に舌鼓だ
-Dialogue: 0,0:06:53.51,0:06:56.38,Default,,0,0,0,,I can see that.
-Dialogue: 0,0:06:53.58,0:06:56.28,Default-ja,,0,0,0,,そんなの\N見れば分かるでございますわ！
-Dialogue: 0,0:06:56.48,0:07:00.54,Default,,0,0,0,,Why are you spreading\Na mat in someone else's yard?
-Dialogue: 0,0:06:56.58,0:07:00.58,Default-ja,,0,0,0,,どうして人さまのお庭で\Nゴザなんか広げてますのよ？
-Dialogue: 0,0:07:00.65,0:07:04.24,Default,,0,0,0,,The shrine is public!\NDon't think it's yours!
-Dialogue: 0,0:07:00.68,0:07:04.22,Default-ja,,0,0,0,,神社は公共の場所だぞ\N勝手に独占するな！
-Dialogue: 0,0:07:04.79,0:07:10.09,Default,,0,0,0,,Keiichi's right.\NLet's make this everyone's yard.
-Dialogue: 0,0:07:04.82,0:07:07.06,Default-ja,,0,0,0,,（梨花）圭一の言うとおりですよ
+Dialogue: 0,0:06:26.08,0:06:28.62,Default-ja,,0,0,0,,{\c&HFFFAFA&}う{\c&HFFFAFA&}{\c&HCCFFFF&}～{\c&HCCFFFF&}{\c&HFFFFFF&}ん{\c&HFFFFFF&}{\c&HCCFFFF&}…{\c&HCCFFFF&}{\c&HCCFFCC&}すごい{\c&HCCFFCC&}{\c&HFFFFCC&}量{\c&HFFFFCC&}だ
+Dialogue: 0,0:06:26.28,0:06:28.51,Default,,0,0,0,,{\c&HFFFAFA&}Gee{\c&HFFFAFA&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HFFFFFF&}that's{\c&HFFFFFF&} {\c&HCCFFFF&}a{\c&HCCFFFF&} {\c&HCCFFCC&}lot{\c&HCCFFCC&} {\c&HFFFFCC&}.{\c&HFFFFCC&}
+Dialogue: 0,0:06:28.95,0:06:31.09,Default-ja,,0,0,0,,{\c&HFFCCCC&}（{\c&HFFCCCC&}{\c&HFFCCFF&}梨花{\c&HFFCCFF&}(りか)）こんにちはです\N（圭一）はぁ？
+Dialogue: 0,0:06:28.98,0:06:30.51,Default,,0,0,0,,{\c&HFFCCCC&}Hello{\c&HFFCCCC&} {\c&HFFCCFF&}.{\c&HFFCCFF&}
+Dialogue: 0,0:06:31.19,0:06:32.85,Default-ja,,0,0,0,,{\c&HCCE5FF&}（{\c&HCCE5FF&}{\c&HFFD8B1&}魅{\c&HFFD8B1&}{\c&HCCE0FF&}音{\c&HCCE0FF&}{\c&HFFFFE0&}）{\c&HFFFFE0&}{\c&HFFF0F5&}オッ{\c&HFFF0F5&}{\c&HFFE4E1&}！{\c&HFFE4E1&}来た来た
+Dialogue: 0,0:06:31.29,0:06:33.25,Default,,0,0,0,,{\c&HCCE5FF&}Oh{\c&HCCE5FF&} {\c&HFFD8B1&},{\c&HFFD8B1&} {\c&HCCE0FF&}there{\c&HCCE0FF&} {\c&HFFFFE0&}you{\c&HFFFFE0&} {\c&HFFF0F5&}are{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
+Dialogue: 0,0:06:33.26,0:06:35.16,Default-ja,,0,0,0,,{\c&HFAFAD2&}（{\c&HFAFAD2&}{\c&HFFFACD&}圭一{\c&HFFFACD&}{\c&HFFEFD5&}）{\c&HFFEFD5&}{\c&HFFFFF0&}沙都子{\c&HFFFFF0&}{\c&HFFF5EE&}({\c&HFFF5EE&}{\c&HFAEBD7&}さとこ{\c&HFAEBD7&})に梨花ちゃん？
+Dialogue: 0,0:06:33.35,0:06:35.75,Default,,0,0,0,,{\c&HFAFAD2&}Satoko{\c&HFAFAD2&} {\c&HFFFACD&}and{\c&HFFFACD&} {\c&HFFEFD5&}Rika{\c&HFFEFD5&} {\c&HFFFFF0&}-{\c&HFFFFF0&} {\c&HFFF5EE&}chan{\c&HFFF5EE&} {\c&HFAEBD7&}?{\c&HFAEBD7&}
+Dialogue: 0,0:06:35.99,0:06:40.73,Default-ja,,0,0,0,,{\c&HFFFAFA&}この{\c&HFFFAFA&}{\c&HCCFFFF&}２{\c&HCCFFFF&}{\c&HFFFFFF&}人{\c&HFFFFFF&}{\c&HCCFFFF&}は{\c&HCCFFFF&}{\c&HCCFFCC&}俺{\c&HCCFFCC&}{\c&HFFFFCC&}の{\c&HFFFFCC&}{\c&HFFCCCC&}クラスメート{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}北条{\c&HCCE0FF&}{\c&HFFFFE0&}({\c&HFFFFE0&}ほうじょう)沙都子と古手(ふるで)梨花
+Dialogue: 0,0:06:36.02,0:06:40.69,Default,,0,0,0,,{\c&HFFFAFA&}These{\c&HFFFAFA&} {\c&HCCFFFF&}two{\c&HCCFFFF&} {\c&HFFFFFF&}are{\c&HFFFFFF&} {\c&HCCFFFF&}my{\c&HCCFFFF&} {\c&HCCFFCC&}classmates{\c&HCCFFCC&} {\c&HFFFFCC&},\{\c&HFFFFCC&} {\c&HFFCCCC&}NSatoko{\c&HFFCCCC&} {\c&HFFCCFF&}Hojo{\c&HFFCCFF&} {\c&HCCE5FF&}and{\c&HCCE5FF&} {\c&HFFD8B1&}Rika{\c&HFFD8B1&} {\c&HCCE0FF&}Furude{\c&HCCE0FF&} {\c&HFFFFE0&}.{\c&HFFFFE0&}
+Dialogue: 0,0:06:40.80,0:06:43.53,Default,,0,0,0,,{\c&HFFF0F5&}They're{\c&HFFF0F5&} {\c&HFFE4E1&}underclassmen{\c&HFFE4E1&} {\c&HFAFAD2&}of{\c&HFAFAD2&} {\c&HFFFACD&}course{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:06:40.83,0:06:43.83,Default-ja,,0,0,0,,{\c&HFFF0F5&}…{\c&HFFF0F5&}{\c&HFFE4E1&}と{\c&HFFE4E1&}{\c&HFAFAD2&}は{\c&HFAFAD2&}{\c&HFFFACD&}いっ{\c&HFFFACD&}{\c&HFFEFD5&}て{\c&HFFEFD5&}も\Nもちろん学年は下だけど
+Dialogue: 0,0:06:44.67,0:06:47.36,Default,,0,0,0,,{\c&HFFFFF0&}What's{\c&HFFFFF0&} {\c&HFFF5EE&}with{\c&HFFF5EE&} {\c&HFAEBD7&}all{\c&HFAEBD7&} {\c&HFFFAFA&}this{\c&HFFFAFA&} {\c&HCCFFFF&}excitement{\c&HCCFFFF&} {\c&HFFFFFF&}?{\c&HFFFFFF&}
+Dialogue: 0,0:06:44.70,0:06:47.30,Default-ja,,0,0,0,,{\c&HFFFFF0&}（{\c&HFFFFF0&}{\c&HFFF5EE&}沙都子{\c&HFFF5EE&}{\c&HFAEBD7&}）{\c&HFAEBD7&}{\c&HFFFAFA&}\{\c&HFFFAFA&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HFFFFFF&}これ{\c&HFFFFFF&}は一体何の騒ぎですの？
+Dialogue: 0,0:06:47.74,0:06:49.46,Default,,0,0,0,,{\c&HCCFFFF&}Can't{\c&HCCFFFF&} {\c&HCCFFCC&}you{\c&HCCFFCC&} {\c&HFFFFCC&}tell{\c&HFFFFCC&} {\c&HFFCCCC&}?{\c&HFFCCCC&}
+Dialogue: 0,0:06:47.74,0:06:49.54,Default-ja,,0,0,0,,{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HCCFFCC&}圭一{\c&HCCFFCC&}{\c&HFFFFCC&}）{\c&HFFFFCC&}{\c&HFFCCCC&}見りゃ{\c&HFFCCCC&}分かるだろう
+Dialogue: 0,0:06:49.57,0:06:52.87,Default,,0,0,0,,{\c&HFFCCFF&}We're{\c&HFFCCFF&} {\c&HCCE5FF&}about{\c&HCCE5FF&} {\c&HFFD8B1&}to{\c&HFFD8B1&} {\c&HCCE0FF&}enjoy{\c&HCCE0FF&} {\c&HFFFFE0&}Rena's{\c&HFFFFE0&} {\c&HFFF0F5&}\{\c&HFFF0F5&} {\c&HFFE4E1&}Nhomemade{\c&HFFE4E1&} {\c&HFAFAD2&}boxed{\c&HFAFAD2&} {\c&HFFFACD&}lunches{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:06:49.64,0:06:52.81,Default-ja,,0,0,0,,{\c&HFFCCFF&}これから{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}レナ{\c&HCCE0FF&}{\c&HFFFFE0&}の{\c&HFFFFE0&}{\c&HFFF0F5&}手作り{\c&HFFF0F5&}{\c&HFFE4E1&}弁当{\c&HFFE4E1&}{\c&HFAFAD2&}に{\c&HFAFAD2&}{\c&HFFFACD&}舌鼓{\c&HFFFACD&}{\c&HFFEFD5&}だ{\c&HFFEFD5&}
+Dialogue: 0,0:06:53.51,0:06:56.38,Default,,0,0,0,,{\c&HFFFFF0&}I{\c&HFFFFF0&} {\c&HFFF5EE&}can{\c&HFFF5EE&} {\c&HFAEBD7&}see{\c&HFAEBD7&} {\c&HFFFAFA&}that{\c&HFFFAFA&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:06:53.58,0:06:56.28,Default-ja,,0,0,0,,{\c&HFFFFF0&}そんな{\c&HFFFFF0&}{\c&HFFF5EE&}の{\c&HFFF5EE&}{\c&HFAEBD7&}\{\c&HFAEBD7&}{\c&HFFFAFA&}N{\c&HFFFAFA&}{\c&HCCFFFF&}見れ{\c&HCCFFFF&}ば分かるでございますわ！
+Dialogue: 0,0:06:56.48,0:07:00.54,Default,,0,0,0,,{\c&HFFFFFF&}Why{\c&HFFFFFF&} {\c&HCCFFFF&}are{\c&HCCFFFF&} {\c&HCCFFCC&}you{\c&HCCFFCC&} {\c&HFFFFCC&}spreading{\c&HFFFFCC&} {\c&HFFCCCC&}\{\c&HFFCCCC&} {\c&HFFCCFF&}Na{\c&HFFCCFF&} {\c&HCCE5FF&}mat{\c&HCCE5FF&} {\c&HFFD8B1&}in{\c&HFFD8B1&} {\c&HCCE0FF&}someone{\c&HCCE0FF&} {\c&HFFFFE0&}else's{\c&HFFFFE0&} {\c&HFFF0F5&}yard{\c&HFFF0F5&} {\c&HFFE4E1&}?{\c&HFFE4E1&}
+Dialogue: 0,0:06:56.58,0:07:00.58,Default-ja,,0,0,0,,{\c&HFFFFFF&}どうして{\c&HFFFFFF&}{\c&HCCFFFF&}人さま{\c&HCCFFFF&}{\c&HCCFFCC&}の{\c&HCCFFCC&}{\c&HFFFFCC&}お{\c&HFFFFCC&}{\c&HFFCCCC&}庭{\c&HFFCCCC&}{\c&HFFCCFF&}で{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}ゴザ{\c&HCCE0FF&}{\c&HFFFFE0&}なんか{\c&HFFFFE0&}{\c&HFFF0F5&}広げ{\c&HFFF0F5&}{\c&HFFE4E1&}て{\c&HFFE4E1&}ますのよ？
+Dialogue: 0,0:07:00.65,0:07:04.24,Default,,0,0,0,,{\c&HFAFAD2&}The{\c&HFAFAD2&} {\c&HFFFACD&}shrine{\c&HFFFACD&} {\c&HFFEFD5&}is{\c&HFFEFD5&} {\c&HFFFFF0&}public{\c&HFFFFF0&} {\c&HFFF5EE&}!\{\c&HFFF5EE&} {\c&HFAEBD7&}NDon't{\c&HFAEBD7&} {\c&HFFFAFA&}think{\c&HFFFAFA&} {\c&HCCFFFF&}it's{\c&HCCFFFF&} {\c&HFFFFFF&}yours{\c&HFFFFFF&} {\c&HCCFFFF&}!{\c&HCCFFFF&}
+Dialogue: 0,0:07:00.68,0:07:04.22,Default-ja,,0,0,0,,{\c&HFAFAD2&}神社{\c&HFAFAD2&}{\c&HFFFACD&}は{\c&HFFFACD&}{\c&HFFEFD5&}公共{\c&HFFEFD5&}{\c&HFFFFF0&}の{\c&HFFFFF0&}{\c&HFFF5EE&}場所{\c&HFFF5EE&}{\c&HFAEBD7&}だ{\c&HFAEBD7&}{\c&HFFFAFA&}ぞ{\c&HFFFAFA&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}{\c&HCCFFFF&}勝手{\c&HCCFFFF&}に独占するな！
+Dialogue: 0,0:07:04.79,0:07:10.09,Default,,0,0,0,,{\c&HCCFFCC&}Keiichi's{\c&HCCFFCC&} {\c&HFFFFCC&}right{\c&HFFFFCC&} {\c&HFFCCCC&}.\{\c&HFFCCCC&} {\c&HFFCCFF&}NLet's{\c&HFFCCFF&} {\c&HCCE5FF&}make{\c&HCCE5FF&} {\c&HFFD8B1&}this{\c&HFFD8B1&} {\c&HCCE0FF&}everyone's{\c&HCCE0FF&} {\c&HFFFFE0&}yard{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:07:04.82,0:07:07.06,Default-ja,,0,0,0,,{\c&HCCFFCC&}（{\c&HCCFFCC&}{\c&HFFFFCC&}梨花{\c&HFFFFCC&}{\c&HFFCCCC&}）{\c&HFFCCCC&}{\c&HFFCCFF&}圭一{\c&HFFCCFF&}{\c&HCCE5FF&}の{\c&HCCE5FF&}{\c&HFFD8B1&}言う{\c&HFFD8B1&}{\c&HCCE0FF&}とおり{\c&HCCE0FF&}{\c&HFFFFE0&}です{\c&HFFFFE0&}{\c&HFFF0F5&}よ{\c&HFFF0F5&}
 Dialogue: 0,0:07:07.16,0:07:09.16,Default-ja,,0,0,0,,みんなのお庭にしますです
-Dialogue: 0,0:07:09.32,0:07:13.06,Default-ja,,0,0,0,,ク～ッ！ やっぱり\N梨花ちゃんは いい子だなぁ
-Dialogue: 0,0:07:10.19,0:07:13.09,Default,,0,0,0,,Rika's really a good girl!
-Dialogue: 0,0:07:13.16,0:07:15.26,Default-ja,,0,0,0,,座りな そこ！ 一緒に食べよう
-Dialogue: 0,0:07:13.19,0:07:15.96,Default,,0,0,0,,Sit over there!\NLet's eat together!
-Dialogue: 0,0:07:15.56,0:07:18.73,Default-ja,,0,0,0,,（口笛）\N（沙都子）しょうがないですわね
-Dialogue: 0,0:07:16.83,0:07:22.27,Default,,0,0,0,,I guess I have no choice.\NI will join you all.
-Dialogue: 0,0:07:18.83,0:07:22.70,Default-ja,,0,0,0,,せっかくですから\N私も ご一緒してさし上げましてよ
-Dialogue: 0,0:07:22.74,0:07:26.23,Default,,0,0,0,,There's no room for you\Nto sit and not enough food.
+Dialogue: 0,0:07:09.32,0:07:13.06,Default-ja,,0,0,0,,{\c&HFFE4E1&}ク{\c&HFFE4E1&}{\c&HFAFAD2&}～{\c&HFAFAD2&}{\c&HFFFACD&}ッ{\c&HFFFACD&}{\c&HFFEFD5&}！{\c&HFFEFD5&}{\c&HFFFFF0&}やっぱり{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}N梨花ちゃんはいい子だなぁ
+Dialogue: 0,0:07:10.19,0:07:13.09,Default,,0,0,0,,{\c&HFFE4E1&}Rika's{\c&HFFE4E1&} {\c&HFAFAD2&}really{\c&HFAFAD2&} {\c&HFFFACD&}a{\c&HFFFACD&} {\c&HFFEFD5&}good{\c&HFFEFD5&} {\c&HFFFFF0&}girl{\c&HFFFFF0&} {\c&HFFF5EE&}!{\c&HFFF5EE&}
+Dialogue: 0,0:07:13.16,0:07:15.26,Default-ja,,0,0,0,,{\c&HFAEBD7&}座り{\c&HFAEBD7&}{\c&HFFFAFA&}な{\c&HFFFAFA&}{\c&HCCFFFF&}そこ{\c&HCCFFFF&}{\c&HFFFFFF&}！{\c&HFFFFFF&}{\c&HCCFFFF&}一緒{\c&HCCFFFF&}{\c&HCCFFCC&}に{\c&HCCFFCC&}{\c&HFFFFCC&}食べよ{\c&HFFFFCC&}{\c&HFFCCCC&}う{\c&HFFCCCC&}
+Dialogue: 0,0:07:13.19,0:07:15.96,Default,,0,0,0,,{\c&HFAEBD7&}Sit{\c&HFAEBD7&} {\c&HFFFAFA&}over{\c&HFFFAFA&} {\c&HCCFFFF&}there{\c&HCCFFFF&} {\c&HFFFFFF&}!\{\c&HFFFFFF&} {\c&HCCFFFF&}NLet's{\c&HCCFFFF&} {\c&HCCFFCC&}eat{\c&HCCFFCC&} {\c&HFFFFCC&}together{\c&HFFFFCC&} {\c&HFFCCCC&}!{\c&HFFCCCC&}
+Dialogue: 0,0:07:15.56,0:07:18.73,Default-ja,,0,0,0,,{\c&HFFCCFF&}（{\c&HFFCCFF&}{\c&HCCE5FF&}口笛{\c&HCCE5FF&}{\c&HFFD8B1&}）\{\c&HFFD8B1&}{\c&HCCE0FF&}N{\c&HCCE0FF&}{\c&HFFFFE0&}（{\c&HFFFFE0&}{\c&HFFF0F5&}沙都子{\c&HFFF0F5&}{\c&HFFE4E1&}）{\c&HFFE4E1&}{\c&HFAFAD2&}しょうが{\c&HFAFAD2&}{\c&HFFFACD&}ない{\c&HFFFACD&}{\c&HFFEFD5&}です{\c&HFFEFD5&}{\c&HFFFFF0&}わ{\c&HFFFFF0&}{\c&HFFF5EE&}ね{\c&HFFF5EE&}
+Dialogue: 0,0:07:16.83,0:07:22.27,Default,,0,0,0,,{\c&HFFCCFF&}I{\c&HFFCCFF&} {\c&HCCE5FF&}guess{\c&HCCE5FF&} {\c&HFFD8B1&}I{\c&HFFD8B1&} {\c&HCCE0FF&}have{\c&HCCE0FF&} {\c&HFFFFE0&}no{\c&HFFFFE0&} {\c&HFFF0F5&}choice{\c&HFFF0F5&} {\c&HFFE4E1&}.\{\c&HFFE4E1&} {\c&HFAFAD2&}NI{\c&HFAFAD2&} {\c&HFFFACD&}will{\c&HFFFACD&} {\c&HFFEFD5&}join{\c&HFFEFD5&} {\c&HFFFFF0&}you{\c&HFFFFF0&} {\c&HFFF5EE&}all{\c&HFFF5EE&} .
+Dialogue: 0,0:07:18.83,0:07:22.70,Default-ja,,0,0,0,,{\c&HFAEBD7&}せっかく{\c&HFAEBD7&}{\c&HFFFAFA&}です{\c&HFFFAFA&}{\c&HCCFFFF&}から{\c&HCCFFFF&}{\c&HFFFFFF&}\{\c&HFFFFFF&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HCCFFCC&}私{\c&HCCFFCC&}{\c&HFFFFCC&}も{\c&HFFFFCC&}{\c&HFFCCCC&}ご{\c&HFFCCCC&}{\c&HFFCCFF&}一緒{\c&HFFCCFF&}{\c&HCCE5FF&}し{\c&HCCE5FF&}{\c&HFFD8B1&}て{\c&HFFD8B1&}{\c&HCCE0FF&}さし{\c&HCCE0FF&}{\c&HFFFFE0&}上げ{\c&HFFFFE0&}ましてよ
+Dialogue: 0,0:07:22.74,0:07:26.23,Default,,0,0,0,,{\c&HFAEBD7&}There's{\c&HFAEBD7&} {\c&HFFFAFA&}no{\c&HFFFAFA&} {\c&HCCFFFF&}room{\c&HCCFFFF&} {\c&HFFFFFF&}for{\c&HFFFFFF&} {\c&HCCFFFF&}you{\c&HCCFFFF&} {\c&HCCFFCC&}\{\c&HCCFFCC&} {\c&HFFFFCC&}Nto{\c&HFFFFCC&} {\c&HFFCCCC&}sit{\c&HFFCCCC&} {\c&HFFCCFF&}and{\c&HFFCCFF&} {\c&HCCE5FF&}not{\c&HCCE5FF&} {\c&HFFD8B1&}enough{\c&HFFD8B1&} {\c&HCCE0FF&}food{\c&HCCE0FF&} {\c&HFFFFE0&}.{\c&HFFFFE0&}
 Dialogue: 0,0:07:22.80,0:07:25.77,Default-ja,,0,0,0,,お前に座る場所はないし\N食べる分もない
-Dialogue: 0,0:07:25.87,0:07:27.34,Default-ja,,0,0,0,,ベーッ！\N（沙都子）なんですって？
-Dialogue: 0,0:07:26.57,0:07:28.54,Default,,0,0,0,,What did you say?
+Dialogue: 0,0:07:25.87,0:07:27.34,Default-ja,,0,0,0,,{\c&HFFF0F5&}ベーッ{\c&HFFF0F5&}{\c&HFFE4E1&}！\{\c&HFFE4E1&}{\c&HFAFAD2&}N{\c&HFAFAD2&}{\c&HFFFACD&}（{\c&HFFFACD&}{\c&HFFEFD5&}沙都子{\c&HFFEFD5&}）なんですって？
+Dialogue: 0,0:07:26.57,0:07:28.54,Default,,0,0,0,,{\c&HFFF0F5&}What{\c&HFFF0F5&} {\c&HFFE4E1&}did{\c&HFFE4E1&} {\c&HFAFAD2&}you{\c&HFAFAD2&} {\c&HFFFACD&}say{\c&HFFFACD&} {\c&HFFEFD5&}?{\c&HFFEFD5&}
 Dialogue: 0,0:07:27.68,0:07:29.91,Default-ja,,0,0,0,,（沙都子）ンンッ！\N（圭一）や～い や～い！
-Dialogue: 0,0:07:30.01,0:07:31.81,Default-ja,,0,0,0,,（ﾚﾅ）大丈夫だよ
-Dialogue: 0,0:07:30.08,0:07:34.84,Default,,0,0,0,,It's okay. There's enough\Nfor Satoko-chan too.
-Dialogue: 0,0:07:31.91,0:07:34.85,Default-ja,,0,0,0,,沙都子ちゃんの分も\Nちゃんとあるから
-Dialogue: 0,0:07:34.95,0:07:37.82,Default,,0,0,0,,Nope, I'm going\Nto have Satoko's share.
-Dialogue: 0,0:07:34.95,0:07:37.82,Default-ja,,0,0,0,,（圭一）\Nない！ 沙都子の分も俺がいただく
-Dialogue: 0,0:07:37.92,0:07:39.98,Default,,0,0,0,,I won't let you!
-Dialogue: 0,0:07:37.92,0:07:40.02,Default-ja,,0,0,0,,（沙都子）\Nそんなことは許せませんの！
-Dialogue: 0,0:07:40.76,0:07:42.66,Default,,0,0,0,,Here are the chopsticks.
+Dialogue: 0,0:07:30.01,0:07:31.81,Default-ja,,0,0,0,,{\c&HFFFFF0&}（{\c&HFFFFF0&}{\c&HFFF5EE&}ﾚﾅ{\c&HFFF5EE&}{\c&HFAEBD7&}）{\c&HFAEBD7&}{\c&HFFFAFA&}大丈夫{\c&HFFFAFA&}{\c&HCCFFFF&}だ{\c&HCCFFFF&}{\c&HFFFFFF&}よ{\c&HFFFFFF&}
+Dialogue: 0,0:07:30.08,0:07:34.84,Default,,0,0,0,,{\c&HFFFFF0&}It's{\c&HFFFFF0&} {\c&HFFF5EE&}okay{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&} {\c&HFFFAFA&}There's{\c&HFFFAFA&} {\c&HCCFFFF&}enough{\c&HCCFFFF&} {\c&HFFFFFF&}\{\c&HFFFFFF&} Nfor Satoko - chan too .
+Dialogue: 0,0:07:31.91,0:07:34.85,Default-ja,,0,0,0,,{\c&HCCFFFF&}沙都子{\c&HCCFFFF&}{\c&HCCFFCC&}ちゃん{\c&HCCFFCC&}{\c&HFFFFCC&}の{\c&HFFFFCC&}{\c&HFFCCCC&}分{\c&HFFCCCC&}{\c&HFFCCFF&}も{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}ちゃんと{\c&HCCE0FF&}{\c&HFFFFE0&}ある{\c&HFFFFE0&}{\c&HFFF0F5&}から{\c&HFFF0F5&}
+Dialogue: 0,0:07:34.95,0:07:37.82,Default,,0,0,0,,{\c&HCCFFFF&}Nope{\c&HCCFFFF&} {\c&HCCFFCC&},{\c&HCCFFCC&} {\c&HFFFFCC&}I'm{\c&HFFFFCC&} {\c&HFFCCCC&}going{\c&HFFCCCC&} {\c&HFFCCFF&}\{\c&HFFCCFF&} {\c&HCCE5FF&}Nto{\c&HCCE5FF&} {\c&HFFD8B1&}have{\c&HFFD8B1&} {\c&HCCE0FF&}Satoko's{\c&HCCE0FF&} {\c&HFFFFE0&}share{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:07:34.95,0:07:37.82,Default-ja,,0,0,0,,{\c&HFFE4E1&}（{\c&HFFE4E1&}{\c&HFAFAD2&}圭一{\c&HFAFAD2&}{\c&HFFFACD&}）{\c&HFFFACD&}{\c&HFFEFD5&}\{\c&HFFEFD5&}{\c&HFFFFF0&}N{\c&HFFFFF0&}ない！沙都子の分も俺がいただく
+Dialogue: 0,0:07:37.92,0:07:39.98,Default,,0,0,0,,{\c&HFFE4E1&}I{\c&HFFE4E1&} {\c&HFAFAD2&}won't{\c&HFAFAD2&} {\c&HFFFACD&}let{\c&HFFFACD&} {\c&HFFEFD5&}you{\c&HFFEFD5&} {\c&HFFFFF0&}!{\c&HFFFFF0&}
+Dialogue: 0,0:07:37.92,0:07:40.02,Default-ja,,0,0,0,,{\c&HFFF5EE&}（{\c&HFFF5EE&}{\c&HFAEBD7&}沙都子{\c&HFAEBD7&}{\c&HFFFAFA&}）{\c&HFFFAFA&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}そんなことは許せませんの！
+Dialogue: 0,0:07:40.76,0:07:42.66,Default,,0,0,0,,{\c&HFFF5EE&}Here{\c&HFFF5EE&} {\c&HFAEBD7&}are{\c&HFAEBD7&} {\c&HFFFAFA&}the{\c&HFFFAFA&} {\c&HCCFFFF&}chopsticks{\c&HCCFFFF&} {\c&HFFFFFF&}.{\c&HFFFFFF&}
 Dialogue: 0,0:07:40.79,0:07:42.86,Default-ja,,0,0,0,,はい お箸です
-Dialogue: 0,0:07:43.26,0:07:45.23,Default-ja,,0,0,0,,（沙都子）\Nいっただっきま～すですわ
-Dialogue: 0,0:07:43.36,0:07:45.29,Default,,0,0,0,,I'm going to eat!
-Dialogue: 0,0:07:45.33,0:07:47.30,Default-ja,,0,0,0,,俺だって いただきますだ！
-Dialogue: 0,0:07:45.39,0:07:47.69,Default,,0,0,0,,Me too! I'm eating too!
-Dialogue: 0,0:07:48.60,0:07:51.22,Default,,0,0,0,,It's nice to be young.
-Dialogue: 0,0:07:48.66,0:07:51.23,Default-ja,,0,0,0,,いやはや 若いって いいねえ
-Dialogue: 0,0:07:51.57,0:07:55.47,Default,,0,0,0,,Please eat a lot.\NThere's enough for everyone.
-Dialogue: 0,0:07:51.63,0:07:55.60,Default-ja,,0,0,0,,いっぱい食べてね\Nちゃんと みんなの分あるから
-Dialogue: 0,0:07:55.70,0:07:57.69,Default,,0,0,0,,The hamburger steak is mine!
-Dialogue: 0,0:07:55.77,0:07:57.01,Default-ja,,0,0,0,,（圭一）ハンバーグ いただき！
-Dialogue: 0,0:07:57.81,0:08:00.47,Default,,0,0,0,,I am not letting you have it!
-Dialogue: 0,0:07:57.81,0:08:00.61,Default-ja,,0,0,0,,そのハンバーグは渡しませんわ！
-Dialogue: 0,0:08:00.74,0:08:01.88,Default-ja,,0,0,0,,（殴る音）\Nウワッ！
-Dialogue: 0,0:08:02.71,0:08:04.68,Default,,0,0,0,,Elbowing's against the rules...
-Dialogue: 0,0:08:02.78,0:08:04.71,Default-ja,,0,0,0,,（圭一）肘は反則だろう…
-Dialogue: 0,0:08:04.78,0:08:07.48,Default,,0,0,0,,Oh, we had rules?
-Dialogue: 0,0:08:04.81,0:08:07.35,Default-ja,,0,0,0,,（沙都子）\Nあら ルールなんて ありましたの？
-Dialogue: 0,0:08:07.58,0:08:11.07,Default,,0,0,0,,Eating lunch with\Neveryone is so fun! So fun!
+Dialogue: 0,0:07:43.26,0:07:45.23,Default-ja,,0,0,0,,{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HCCFFCC&}沙都子{\c&HCCFFCC&}{\c&HFFFFCC&}）{\c&HFFFFCC&}{\c&HFFCCCC&}\{\c&HFFCCCC&}{\c&HFFCCFF&}N{\c&HFFCCFF&}いっただっきま～すですわ
+Dialogue: 0,0:07:43.36,0:07:45.29,Default,,0,0,0,,{\c&HCCFFFF&}I'm{\c&HCCFFFF&} {\c&HCCFFCC&}going{\c&HCCFFCC&} {\c&HFFFFCC&}to{\c&HFFFFCC&} {\c&HFFCCCC&}eat{\c&HFFCCCC&} {\c&HFFCCFF&}!{\c&HFFCCFF&}
+Dialogue: 0,0:07:45.33,0:07:47.30,Default-ja,,0,0,0,,{\c&HCCE5FF&}俺{\c&HCCE5FF&}{\c&HFFD8B1&}だって{\c&HFFD8B1&}{\c&HCCE0FF&}いただき{\c&HCCE0FF&}{\c&HFFFFE0&}ます{\c&HFFFFE0&}{\c&HFFF0F5&}だ{\c&HFFF0F5&}{\c&HFFE4E1&}！{\c&HFFE4E1&}
+Dialogue: 0,0:07:45.39,0:07:47.69,Default,,0,0,0,,{\c&HCCE5FF&}Me{\c&HCCE5FF&} {\c&HFFD8B1&}too{\c&HFFD8B1&} {\c&HCCE0FF&}!{\c&HCCE0FF&} {\c&HFFFFE0&}I'm{\c&HFFFFE0&} {\c&HFFF0F5&}eating{\c&HFFF0F5&} {\c&HFFE4E1&}too{\c&HFFE4E1&} !
+Dialogue: 0,0:07:48.60,0:07:51.22,Default,,0,0,0,,{\c&HFAFAD2&}It's{\c&HFAFAD2&} {\c&HFFFACD&}nice{\c&HFFFACD&} {\c&HFFEFD5&}to{\c&HFFEFD5&} {\c&HFFFFF0&}be{\c&HFFFFF0&} {\c&HFFF5EE&}young{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:07:48.66,0:07:51.23,Default-ja,,0,0,0,,{\c&HFAFAD2&}いや{\c&HFAFAD2&}{\c&HFFFACD&}はや{\c&HFFFACD&}{\c&HFFEFD5&}若い{\c&HFFEFD5&}{\c&HFFFFF0&}って{\c&HFFFFF0&}{\c&HFFF5EE&}いい{\c&HFFF5EE&}{\c&HFAEBD7&}ねえ{\c&HFAEBD7&}
+Dialogue: 0,0:07:51.57,0:07:55.47,Default,,0,0,0,,{\c&HFFFAFA&}Please{\c&HFFFAFA&} {\c&HCCFFFF&}eat{\c&HCCFFFF&} {\c&HFFFFFF&}a{\c&HFFFFFF&} {\c&HCCFFFF&}lot{\c&HCCFFFF&} {\c&HCCFFCC&}.\{\c&HCCFFCC&} {\c&HFFFFCC&}NThere's{\c&HFFFFCC&} {\c&HFFCCCC&}enough{\c&HFFCCCC&} {\c&HFFCCFF&}for{\c&HFFCCFF&} {\c&HCCE5FF&}everyone{\c&HCCE5FF&} {\c&HFFD8B1&}.{\c&HFFD8B1&}
+Dialogue: 0,0:07:51.63,0:07:55.60,Default-ja,,0,0,0,,{\c&HFFFAFA&}いっぱい{\c&HFFFAFA&}{\c&HCCFFFF&}食べ{\c&HCCFFFF&}{\c&HFFFFFF&}て{\c&HFFFFFF&}{\c&HCCFFFF&}ね{\c&HCCFFFF&}{\c&HCCFFCC&}\{\c&HCCFFCC&}{\c&HFFFFCC&}N{\c&HFFFFCC&}{\c&HFFCCCC&}ちゃんと{\c&HFFCCCC&}{\c&HFFCCFF&}みんな{\c&HFFCCFF&}{\c&HCCE5FF&}の{\c&HCCE5FF&}{\c&HFFD8B1&}分{\c&HFFD8B1&}あるから
+Dialogue: 0,0:07:55.70,0:07:57.69,Default,,0,0,0,,{\c&HCCE0FF&}The{\c&HCCE0FF&} {\c&HFFFFE0&}hamburger{\c&HFFFFE0&} {\c&HFFF0F5&}steak{\c&HFFF0F5&} {\c&HFFE4E1&}is{\c&HFFE4E1&} {\c&HFAFAD2&}mine{\c&HFAFAD2&} {\c&HFFFACD&}!{\c&HFFFACD&}
+Dialogue: 0,0:07:55.77,0:07:57.01,Default-ja,,0,0,0,,{\c&HCCE0FF&}（{\c&HCCE0FF&}{\c&HFFFFE0&}圭一{\c&HFFFFE0&}{\c&HFFF0F5&}）{\c&HFFF0F5&}{\c&HFFE4E1&}ハンバーグ{\c&HFFE4E1&}{\c&HFAFAD2&}いただき{\c&HFAFAD2&}{\c&HFFFACD&}！{\c&HFFFACD&}
+Dialogue: 0,0:07:57.81,0:08:00.47,Default,,0,0,0,,{\c&HFFEFD5&}I{\c&HFFEFD5&} {\c&HFFFFF0&}am{\c&HFFFFF0&} {\c&HFFF5EE&}not{\c&HFFF5EE&} {\c&HFAEBD7&}letting{\c&HFAEBD7&} {\c&HFFFAFA&}you{\c&HFFFAFA&} {\c&HCCFFFF&}have{\c&HCCFFFF&} {\c&HFFFFFF&}it{\c&HFFFFFF&} {\c&HCCFFFF&}!{\c&HCCFFFF&}
+Dialogue: 0,0:07:57.81,0:08:00.61,Default-ja,,0,0,0,,{\c&HFFEFD5&}その{\c&HFFEFD5&}{\c&HFFFFF0&}ハンバーグ{\c&HFFFFF0&}{\c&HFFF5EE&}は{\c&HFFF5EE&}{\c&HFAEBD7&}渡し{\c&HFAEBD7&}{\c&HFFFAFA&}ませ{\c&HFFFAFA&}{\c&HCCFFFF&}ん{\c&HCCFFFF&}{\c&HFFFFFF&}わ{\c&HFFFFFF&}{\c&HCCFFFF&}！{\c&HCCFFFF&}
+Dialogue: 0,0:08:00.74,0:08:01.88,Default-ja,,0,0,0,,{\c&HCCFFCC&}（{\c&HCCFFCC&}{\c&HFFFFCC&}殴る{\c&HFFFFCC&}{\c&HFFCCCC&}音{\c&HFFCCCC&}{\c&HFFCCFF&}）\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}ウワッ！
+Dialogue: 0,0:08:02.71,0:08:04.68,Default,,0,0,0,,{\c&HCCFFCC&}Elbowing's{\c&HCCFFCC&} {\c&HFFFFCC&}against{\c&HFFFFCC&} {\c&HFFCCCC&}the{\c&HFFCCCC&} {\c&HFFCCFF&}rules{\c&HFFCCFF&} {\c&HCCE5FF&}...{\c&HCCE5FF&}
+Dialogue: 0,0:08:02.78,0:08:04.71,Default-ja,,0,0,0,,{\c&HFFD8B1&}（{\c&HFFD8B1&}{\c&HCCE0FF&}圭一{\c&HCCE0FF&}{\c&HFFFFE0&}）{\c&HFFFFE0&}{\c&HFFF0F5&}肘{\c&HFFF0F5&}{\c&HFFE4E1&}は{\c&HFFE4E1&}{\c&HFAFAD2&}反則{\c&HFAFAD2&}だろう…
+Dialogue: 0,0:08:04.78,0:08:07.48,Default,,0,0,0,,{\c&HFFD8B1&}Oh{\c&HFFD8B1&} {\c&HCCE0FF&},{\c&HCCE0FF&} {\c&HFFFFE0&}we{\c&HFFFFE0&} {\c&HFFF0F5&}had{\c&HFFF0F5&} {\c&HFFE4E1&}rules{\c&HFFE4E1&} {\c&HFAFAD2&}?{\c&HFAFAD2&}
+Dialogue: 0,0:08:04.81,0:08:07.35,Default-ja,,0,0,0,,{\c&HFFFACD&}（{\c&HFFFACD&}{\c&HFFEFD5&}沙都子{\c&HFFEFD5&}{\c&HFFFFF0&}）{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}{\c&HFAEBD7&}N{\c&HFAEBD7&}{\c&HFFFAFA&}あら{\c&HFFFAFA&}{\c&HCCFFFF&}ルール{\c&HCCFFFF&}{\c&HFFFFFF&}なんて{\c&HFFFFFF&}{\c&HCCFFFF&}あり{\c&HCCFFFF&}{\c&HCCFFCC&}まし{\c&HCCFFCC&}{\c&HFFFFCC&}た{\c&HFFFFCC&}{\c&HFFCCCC&}の{\c&HFFCCCC&}？
+Dialogue: 0,0:08:07.58,0:08:11.07,Default,,0,0,0,,{\c&HFFFACD&}Eating{\c&HFFFACD&} {\c&HFFEFD5&}lunch{\c&HFFEFD5&} {\c&HFFFFF0&}with{\c&HFFFFF0&} {\c&HFFF5EE&}\{\c&HFFF5EE&} {\c&HFAEBD7&}Neveryone{\c&HFAEBD7&} {\c&HFFFAFA&}is{\c&HFFFAFA&} {\c&HCCFFFF&}so{\c&HCCFFFF&} {\c&HFFFFFF&}fun{\c&HFFFFFF&} {\c&HCCFFFF&}!{\c&HCCFFFF&} {\c&HCCFFCC&}So{\c&HCCFFCC&} {\c&HFFFFCC&}fun{\c&HFFFFCC&} {\c&HFFCCCC&}!{\c&HFFCCCC&}
 Dialogue: 0,0:08:07.65,0:08:11.05,Default-ja,,0,0,0,,（ﾚﾅ）みんなで お弁当\N楽しいな 楽しいな！
-Dialogue: 0,0:08:11.15,0:08:13.66,Default-ja,,0,0,0,,（梨花）\Nレナのお弁当は おいしいのです
-Dialogue: 0,0:08:11.19,0:08:14.18,Default,,0,0,0,,Rena's boxed\Nlunches are delicious.
-Dialogue: 0,0:08:16.32,0:08:19.26,Default-ja,,0,0,0,,（魅音）\Nんじゃ 今日のところは これで解散
-Dialogue: 0,0:08:16.42,0:08:19.39,Default,,0,0,0,,Okay, let's call it a day.
-Dialogue: 0,0:08:19.36,0:08:21.23,Default-ja,,0,0,0,,レナに圭ちゃん また あしたね
-Dialogue: 0,0:08:19.49,0:08:21.79,Default,,0,0,0,,Rena, Kei-chan, till tomorrow.
-Dialogue: 0,0:08:21.90,0:08:25.33,Default,,0,0,0,,Thanks for today, Mion.\NIt was fun.
-Dialogue: 0,0:08:21.93,0:08:25.23,Default-ja,,0,0,0,,（圭一）魅音 今日は ありがとうな\N楽しかったぜ
-Dialogue: 0,0:08:25.33,0:08:27.40,Default-ja,,0,0,0,,（ﾚﾅ）また あしたね\N（魅音）うん！
-Dialogue: 0,0:08:25.43,0:08:27.73,Default,,0,0,0,,See you tomorrow!
-Dialogue: 0,0:08:29.90,0:08:33.74,Default-ja,,0,0,0,,圭一君も 今日は\Nつきあってくれて ありがとう
-Dialogue: 0,0:08:29.90,0:08:34.97,Default,,0,0,0,,Thanks for coming with us today,\NKeiichi-kun. Did you have fun?
+Dialogue: 0,0:08:11.15,0:08:13.66,Default-ja,,0,0,0,,{\c&HFFCCFF&}（{\c&HFFCCFF&}{\c&HCCE5FF&}梨花{\c&HCCE5FF&}{\c&HFFD8B1&}）{\c&HFFD8B1&}{\c&HCCE0FF&}\{\c&HCCE0FF&}{\c&HFFFFE0&}N{\c&HFFFFE0&}{\c&HFFF0F5&}レナ{\c&HFFF0F5&}{\c&HFFE4E1&}の{\c&HFFE4E1&}お弁当はおいしいのです
+Dialogue: 0,0:08:11.19,0:08:14.18,Default,,0,0,0,,{\c&HFFCCFF&}Rena's{\c&HFFCCFF&} {\c&HCCE5FF&}boxed{\c&HCCE5FF&} {\c&HFFD8B1&}\{\c&HFFD8B1&} {\c&HCCE0FF&}Nlunches{\c&HCCE0FF&} {\c&HFFFFE0&}are{\c&HFFFFE0&} {\c&HFFF0F5&}delicious{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
+Dialogue: 0,0:08:16.32,0:08:19.26,Default-ja,,0,0,0,,{\c&HFAFAD2&}（{\c&HFAFAD2&}{\c&HFFFACD&}魅{\c&HFFFACD&}{\c&HFFEFD5&}音{\c&HFFEFD5&}{\c&HFFFFF0&}）{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}{\c&HFAEBD7&}N{\c&HFAEBD7&}{\c&HFFFAFA&}んじゃ{\c&HFFFAFA&}{\c&HCCFFFF&}今日{\c&HCCFFFF&}のところはこれで解散
+Dialogue: 0,0:08:16.42,0:08:19.39,Default,,0,0,0,,{\c&HFAFAD2&}Okay{\c&HFAFAD2&} {\c&HFFFACD&},{\c&HFFFACD&} {\c&HFFEFD5&}let's{\c&HFFEFD5&} {\c&HFFFFF0&}call{\c&HFFFFF0&} {\c&HFFF5EE&}it{\c&HFFF5EE&} {\c&HFAEBD7&}a{\c&HFAEBD7&} {\c&HFFFAFA&}day{\c&HFFFAFA&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:08:19.36,0:08:21.23,Default-ja,,0,0,0,,{\c&HFFFFFF&}レナ{\c&HFFFFFF&}{\c&HCCFFFF&}に{\c&HCCFFFF&}{\c&HCCFFCC&}圭{\c&HCCFFCC&}{\c&HFFFFCC&}ちゃん{\c&HFFFFCC&}{\c&HFFCCCC&}また{\c&HFFCCCC&}{\c&HFFCCFF&}あした{\c&HFFCCFF&}{\c&HCCE5FF&}ね{\c&HCCE5FF&}
+Dialogue: 0,0:08:19.49,0:08:21.79,Default,,0,0,0,,{\c&HFFFFFF&}Rena{\c&HFFFFFF&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HCCFFCC&}Kei{\c&HCCFFCC&} {\c&HFFFFCC&}-{\c&HFFFFCC&} {\c&HFFCCCC&}chan{\c&HFFCCCC&} {\c&HFFCCFF&},{\c&HFFCCFF&} {\c&HCCE5FF&}till{\c&HCCE5FF&} tomorrow .
+Dialogue: 0,0:08:21.90,0:08:25.33,Default,,0,0,0,,{\c&HFFD8B1&}Thanks{\c&HFFD8B1&} {\c&HCCE0FF&}for{\c&HCCE0FF&} {\c&HFFFFE0&}today{\c&HFFFFE0&} {\c&HFFF0F5&},{\c&HFFF0F5&} {\c&HFFE4E1&}Mion{\c&HFFE4E1&} {\c&HFAFAD2&}.\{\c&HFAFAD2&} {\c&HFFFACD&}NIt{\c&HFFFACD&} {\c&HFFEFD5&}was{\c&HFFEFD5&} {\c&HFFFFF0&}fun{\c&HFFFFF0&} {\c&HFFF5EE&}.{\c&HFFF5EE&}
+Dialogue: 0,0:08:21.93,0:08:25.23,Default-ja,,0,0,0,,{\c&HFFD8B1&}（{\c&HFFD8B1&}{\c&HCCE0FF&}圭一{\c&HCCE0FF&}{\c&HFFFFE0&}）{\c&HFFFFE0&}{\c&HFFF0F5&}魅{\c&HFFF0F5&}{\c&HFFE4E1&}音{\c&HFFE4E1&}{\c&HFAFAD2&}今日{\c&HFAFAD2&}{\c&HFFFACD&}は{\c&HFFFACD&}{\c&HFFEFD5&}ありがとう{\c&HFFEFD5&}{\c&HFFFFF0&}な{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}N楽しかったぜ
+Dialogue: 0,0:08:25.33,0:08:27.40,Default-ja,,0,0,0,,{\c&HFAEBD7&}（{\c&HFAEBD7&}{\c&HFFFAFA&}ﾚﾅ{\c&HFFFAFA&}{\c&HCCFFFF&}）{\c&HCCFFFF&}{\c&HFFFFFF&}また{\c&HFFFFFF&}あしたね\N（魅音）うん！
+Dialogue: 0,0:08:25.43,0:08:27.73,Default,,0,0,0,,{\c&HFAEBD7&}See{\c&HFAEBD7&} {\c&HFFFAFA&}you{\c&HFFFAFA&} {\c&HCCFFFF&}tomorrow{\c&HCCFFFF&} {\c&HFFFFFF&}!{\c&HFFFFFF&}
+Dialogue: 0,0:08:29.90,0:08:33.74,Default-ja,,0,0,0,,{\c&HCCFFFF&}圭一{\c&HCCFFFF&}{\c&HCCFFCC&}君{\c&HCCFFCC&}{\c&HFFFFCC&}も{\c&HFFFFCC&}{\c&HFFCCCC&}今日{\c&HFFCCCC&}{\c&HFFCCFF&}は{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}つきあっ{\c&HCCE0FF&}{\c&HFFFFE0&}て{\c&HFFFFE0&}{\c&HFFF0F5&}くれ{\c&HFFF0F5&}{\c&HFFE4E1&}て{\c&HFFE4E1&}{\c&HFAFAD2&}ありがとう{\c&HFAFAD2&}
+Dialogue: 0,0:08:29.90,0:08:34.97,Default,,0,0,0,,{\c&HCCFFFF&}Thanks{\c&HCCFFFF&} {\c&HCCFFCC&}for{\c&HCCFFCC&} {\c&HFFFFCC&}coming{\c&HFFFFCC&} {\c&HFFCCCC&}with{\c&HFFCCCC&} {\c&HFFCCFF&}us{\c&HFFCCFF&} {\c&HCCE5FF&}today{\c&HCCE5FF&} {\c&HFFD8B1&},\{\c&HFFD8B1&} {\c&HCCE0FF&}NKeiichi{\c&HCCE0FF&} {\c&HFFFFE0&}-{\c&HFFFFE0&} {\c&HFFF0F5&}kun{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&} {\c&HFAFAD2&}Did{\c&HFAFAD2&} you have fun ?
 Dialogue: 0,0:08:33.84,0:08:35.01,Default-ja,,0,0,0,,楽しかった？
-Dialogue: 0,0:08:35.28,0:08:37.38,Default-ja,,0,0,0,,ああ 楽しかった
-Dialogue: 0,0:08:35.38,0:08:37.37,Default,,0,0,0,,Yeah, I did.
-Dialogue: 0,0:08:37.81,0:08:40.22,Default-ja,,0,0,0,,まだ家(うち)に帰るのが惜しいくらいだぜ
-Dialogue: 0,0:08:37.81,0:08:41.27,Default,,0,0,0,,So much that I don't\Nfeel like going home yet.
-Dialogue: 0,0:08:40.75,0:08:46.02,Default-ja,,0,0,0,,あっ じゃあさ ちょっとだけ\N寄り道してもいいかな？ かな？
-Dialogue: 0,0:08:41.38,0:08:45.94,Default,,0,0,0,,Then can we stop by\Nsomewhere? Can we?
-Dialogue: 0,0:08:46.32,0:08:48.66,Default-ja,,0,0,0,,（圭一）寄り道？ 遠いのか？
-Dialogue: 0,0:08:46.39,0:08:48.79,Default,,0,0,0,,Stop by somewhere? Is it far?
-Dialogue: 0,0:08:48.89,0:08:51.26,Default-ja,,0,0,0,,（ﾚﾅ）\Nちょっと歩くけど すぐ済むから
-Dialogue: 0,0:08:48.89,0:08:53.69,Default,,0,0,0,,We'll walk a bit, but it\Nwon't take long. This way!
+Dialogue: 0,0:08:35.28,0:08:37.38,Default-ja,,0,0,0,,{\c&HFFFACD&}ああ{\c&HFFFACD&}{\c&HFFEFD5&}楽しかっ{\c&HFFEFD5&}{\c&HFFFFF0&}た{\c&HFFFFF0&}
+Dialogue: 0,0:08:35.38,0:08:37.37,Default,,0,0,0,,{\c&HFFFACD&}Yeah{\c&HFFFACD&} {\c&HFFEFD5&},{\c&HFFEFD5&} {\c&HFFFFF0&}I{\c&HFFFFF0&} did .
+Dialogue: 0,0:08:37.81,0:08:40.22,Default-ja,,0,0,0,,{\c&HFFF5EE&}まだ{\c&HFFF5EE&}{\c&HFAEBD7&}家{\c&HFAEBD7&}{\c&HFFFAFA&}({\c&HFFFAFA&}{\c&HCCFFFF&}うち{\c&HCCFFFF&}{\c&HFFFFFF&}){\c&HFFFFFF&}{\c&HCCFFFF&}に{\c&HCCFFFF&}{\c&HCCFFCC&}帰る{\c&HCCFFCC&}{\c&HFFFFCC&}の{\c&HFFFFCC&}{\c&HFFCCCC&}が{\c&HFFCCCC&}{\c&HFFCCFF&}惜しい{\c&HFFCCFF&}{\c&HCCE5FF&}くらい{\c&HCCE5FF&}{\c&HFFD8B1&}だ{\c&HFFD8B1&}ぜ
+Dialogue: 0,0:08:37.81,0:08:41.27,Default,,0,0,0,,{\c&HFFF5EE&}So{\c&HFFF5EE&} {\c&HFAEBD7&}much{\c&HFAEBD7&} {\c&HFFFAFA&}that{\c&HFFFAFA&} {\c&HCCFFFF&}I{\c&HCCFFFF&} {\c&HFFFFFF&}don't{\c&HFFFFFF&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HCCFFCC&}Nfeel{\c&HCCFFCC&} {\c&HFFFFCC&}like{\c&HFFFFCC&} {\c&HFFCCCC&}going{\c&HFFCCCC&} {\c&HFFCCFF&}home{\c&HFFCCFF&} {\c&HCCE5FF&}yet{\c&HCCE5FF&} {\c&HFFD8B1&}.{\c&HFFD8B1&}
+Dialogue: 0,0:08:40.75,0:08:46.02,Default-ja,,0,0,0,,{\c&HCCE0FF&}あっ{\c&HCCE0FF&}{\c&HFFFFE0&}じゃ{\c&HFFFFE0&}{\c&HFFF0F5&}あ{\c&HFFF0F5&}{\c&HFFE4E1&}さ{\c&HFFE4E1&}{\c&HFAFAD2&}ちょっと{\c&HFAFAD2&}{\c&HFFFACD&}だけ{\c&HFFFACD&}{\c&HFFEFD5&}\{\c&HFFEFD5&}{\c&HFFFFF0&}N{\c&HFFFFF0&}{\c&HFFF5EE&}寄り道{\c&HFFF5EE&}{\c&HFAEBD7&}し{\c&HFAEBD7&}{\c&HFFFAFA&}て{\c&HFFFAFA&}もいいかな？かな？
+Dialogue: 0,0:08:41.38,0:08:45.94,Default,,0,0,0,,{\c&HCCE0FF&}Then{\c&HCCE0FF&} {\c&HFFFFE0&}can{\c&HFFFFE0&} {\c&HFFF0F5&}we{\c&HFFF0F5&} {\c&HFFE4E1&}stop{\c&HFFE4E1&} {\c&HFAFAD2&}by{\c&HFAFAD2&} {\c&HFFFACD&}\{\c&HFFFACD&} {\c&HFFEFD5&}Nsomewhere{\c&HFFEFD5&} {\c&HFFFFF0&}?{\c&HFFFFF0&} {\c&HFFF5EE&}Can{\c&HFFF5EE&} {\c&HFAEBD7&}we{\c&HFAEBD7&} {\c&HFFFAFA&}?{\c&HFFFAFA&}
+Dialogue: 0,0:08:46.32,0:08:48.66,Default-ja,,0,0,0,,{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HFFFFFF&}圭一{\c&HFFFFFF&}{\c&HCCFFFF&}）{\c&HCCFFFF&}{\c&HCCFFCC&}寄り道{\c&HCCFFCC&}{\c&HFFFFCC&}？{\c&HFFFFCC&}{\c&HFFCCCC&}遠い{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}{\c&HCCE5FF&}か{\c&HCCE5FF&}？
+Dialogue: 0,0:08:46.39,0:08:48.79,Default,,0,0,0,,{\c&HCCFFFF&}Stop{\c&HCCFFFF&} {\c&HFFFFFF&}by{\c&HFFFFFF&} {\c&HCCFFFF&}somewhere{\c&HCCFFFF&} {\c&HCCFFCC&}?{\c&HCCFFCC&} {\c&HFFFFCC&}Is{\c&HFFFFCC&} {\c&HFFCCCC&}it{\c&HFFCCCC&} {\c&HFFCCFF&}far{\c&HFFCCFF&} {\c&HCCE5FF&}?{\c&HCCE5FF&}
+Dialogue: 0,0:08:48.89,0:08:51.26,Default-ja,,0,0,0,,{\c&HFFD8B1&}（{\c&HFFD8B1&}{\c&HCCE0FF&}ﾚﾅ{\c&HCCE0FF&}{\c&HFFFFE0&}）\{\c&HFFFFE0&}{\c&HFFF0F5&}N{\c&HFFF0F5&}{\c&HFFE4E1&}ちょっと{\c&HFFE4E1&}{\c&HFAFAD2&}歩く{\c&HFAFAD2&}{\c&HFFFACD&}けど{\c&HFFFACD&}{\c&HFFEFD5&}すぐ{\c&HFFEFD5&}{\c&HFFFFF0&}済む{\c&HFFFFF0&}{\c&HFFF5EE&}から{\c&HFFF5EE&}
+Dialogue: 0,0:08:48.89,0:08:53.69,Default,,0,0,0,,{\c&HFFD8B1&}We'll{\c&HFFD8B1&} {\c&HCCE0FF&}walk{\c&HCCE0FF&} {\c&HFFFFE0&}a{\c&HFFFFE0&} {\c&HFFF0F5&}bit{\c&HFFF0F5&} {\c&HFFE4E1&},{\c&HFFE4E1&} {\c&HFAFAD2&}but{\c&HFAFAD2&} {\c&HFFFACD&}it{\c&HFFFACD&} {\c&HFFEFD5&}\{\c&HFFEFD5&} {\c&HFFFFF0&}Nwon't{\c&HFFFFF0&} {\c&HFFF5EE&}take{\c&HFFF5EE&} long . This way !
 Dialogue: 0,0:08:51.36,0:08:53.26,Default-ja,,0,0,0,,こっち こっち！\N（圭一）ああっ…
 Dialogue: 0,0:08:53.93,0:08:55.20,Default-ja,,0,0,0,,（ﾚﾅ）アハハッ！
-Dialogue: 0,0:08:55.40,0:09:00.77,Default-ja,,0,0,0,,今日は久しぶりだから\N何があるかな？ 何があるかな？
-Dialogue: 0,0:08:55.50,0:09:01.49,Default,,0,0,0,,Since it's been a while,\NI wonder what's there. I wonder.
-Dialogue: 0,0:09:01.94,0:09:03.63,Default,,0,0,0,,It's been a while?
-Dialogue: 0,0:09:01.94,0:09:03.71,Default-ja,,0,0,0,,（圭一）“久しぶり”って…
-Dialogue: 0,0:09:03.74,0:09:07.67,Default,,0,0,0,,You wanted to come\Nto this garbage dump?
-Dialogue: 0,0:09:03.81,0:09:07.78,Default-ja,,0,0,0,,レナの用は このゴミの山かよー！
-Dialogue: 0,0:09:08.08,0:09:12.98,Default-ja,,0,0,0,,ゴ… ゴミじゃないよ\Nレナにとっては宝の山だもん！
-Dialogue: 0,0:09:08.11,0:09:10.20,Default,,0,0,0,,I-It's not garbage!
-Dialogue: 0,0:09:10.31,0:09:13.11,Default,,0,0,0,,To me,\Nit's a mountain of treasure!
-Dialogue: 0,0:09:13.08,0:09:17.22,Default-ja,,0,0,0,,わあ 新しい山だ\Nワクワク ワクワク！
+Dialogue: 0,0:08:55.40,0:09:00.77,Default-ja,,0,0,0,,{\c&HFAEBD7&}今日{\c&HFAEBD7&}{\c&HFFFAFA&}は{\c&HFFFAFA&}{\c&HCCFFFF&}久しぶり{\c&HCCFFFF&}{\c&HFFFFFF&}だ{\c&HFFFFFF&}{\c&HCCFFFF&}から{\c&HCCFFFF&}{\c&HCCFFCC&}\{\c&HCCFFCC&}{\c&HFFFFCC&}N{\c&HFFFFCC&}{\c&HFFCCCC&}何{\c&HFFCCCC&}{\c&HFFCCFF&}が{\c&HFFCCFF&}{\c&HCCE5FF&}ある{\c&HCCE5FF&}{\c&HFFD8B1&}か{\c&HFFD8B1&}{\c&HCCE0FF&}な{\c&HCCE0FF&}{\c&HFFFFE0&}？{\c&HFFFFE0&}{\c&HFFF0F5&}何{\c&HFFF0F5&}があるかな？
+Dialogue: 0,0:08:55.50,0:09:01.49,Default,,0,0,0,,{\c&HFAEBD7&}Since{\c&HFAEBD7&} {\c&HFFFAFA&}it's{\c&HFFFAFA&} {\c&HCCFFFF&}been{\c&HCCFFFF&} {\c&HFFFFFF&}a{\c&HFFFFFF&} {\c&HCCFFFF&}while{\c&HCCFFFF&} {\c&HCCFFCC&},\{\c&HCCFFCC&} {\c&HFFFFCC&}NI{\c&HFFFFCC&} {\c&HFFCCCC&}wonder{\c&HFFCCCC&} {\c&HFFCCFF&}what's{\c&HFFCCFF&} {\c&HCCE5FF&}there{\c&HCCE5FF&} {\c&HFFD8B1&}.{\c&HFFD8B1&} {\c&HCCE0FF&}I{\c&HCCE0FF&} {\c&HFFFFE0&}wonder{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:09:01.94,0:09:03.63,Default,,0,0,0,,{\c&HFFE4E1&}It's{\c&HFFE4E1&} {\c&HFAFAD2&}been{\c&HFAFAD2&} {\c&HFFFACD&}a{\c&HFFFACD&} {\c&HFFEFD5&}while{\c&HFFEFD5&} {\c&HFFFFF0&}?{\c&HFFFFF0&}
+Dialogue: 0,0:09:01.94,0:09:03.71,Default-ja,,0,0,0,,{\c&HFFE4E1&}（{\c&HFFE4E1&}{\c&HFAFAD2&}圭一{\c&HFAFAD2&}{\c&HFFFACD&}）{\c&HFFFACD&}{\c&HFFEFD5&}“{\c&HFFEFD5&}{\c&HFFFFF0&}久しぶり{\c&HFFFFF0&}”って…
+Dialogue: 0,0:09:03.74,0:09:07.67,Default,,0,0,0,,{\c&HFFF5EE&}You{\c&HFFF5EE&} {\c&HFAEBD7&}wanted{\c&HFAEBD7&} {\c&HFFFAFA&}to{\c&HFFFAFA&} {\c&HCCFFFF&}come{\c&HCCFFFF&} {\c&HFFFFFF&}\{\c&HFFFFFF&} {\c&HCCFFFF&}Nto{\c&HCCFFFF&} {\c&HCCFFCC&}this{\c&HCCFFCC&} {\c&HFFFFCC&}garbage{\c&HFFFFCC&} {\c&HFFCCCC&}dump{\c&HFFCCCC&} {\c&HFFCCFF&}?{\c&HFFCCFF&}
+Dialogue: 0,0:09:03.81,0:09:07.78,Default-ja,,0,0,0,,{\c&HFFF5EE&}レナ{\c&HFFF5EE&}{\c&HFAEBD7&}の{\c&HFAEBD7&}{\c&HFFFAFA&}用{\c&HFFFAFA&}{\c&HCCFFFF&}は{\c&HCCFFFF&}{\c&HFFFFFF&}この{\c&HFFFFFF&}{\c&HCCFFFF&}ゴミ{\c&HCCFFFF&}{\c&HCCFFCC&}の{\c&HCCFFCC&}{\c&HFFFFCC&}山{\c&HFFFFCC&}{\c&HFFCCCC&}か{\c&HFFCCCC&}{\c&HFFCCFF&}よー{\c&HFFCCFF&}！
+Dialogue: 0,0:09:08.08,0:09:12.98,Default-ja,,0,0,0,,{\c&HCCE5FF&}ゴ{\c&HCCE5FF&}{\c&HFFD8B1&}…{\c&HFFD8B1&}{\c&HCCE0FF&}ゴミ{\c&HCCE0FF&}{\c&HFFFFE0&}じゃ{\c&HFFFFE0&}{\c&HFFF0F5&}ない{\c&HFFF0F5&}{\c&HFFE4E1&}よ{\c&HFFE4E1&}\Nレナにとっては宝の山だもん！
+Dialogue: 0,0:09:08.11,0:09:10.20,Default,,0,0,0,,{\c&HCCE5FF&}I{\c&HCCE5FF&} {\c&HFFD8B1&}-{\c&HFFD8B1&} {\c&HCCE0FF&}It's{\c&HCCE0FF&} {\c&HFFFFE0&}not{\c&HFFFFE0&} {\c&HFFF0F5&}garbage{\c&HFFF0F5&} {\c&HFFE4E1&}!{\c&HFFE4E1&}
+Dialogue: 0,0:09:10.31,0:09:13.11,Default,,0,0,0,,{\c&HFAFAD2&}To{\c&HFAFAD2&} {\c&HFFFACD&}me{\c&HFFFACD&} {\c&HFFEFD5&},\{\c&HFFEFD5&} {\c&HFFFFF0&}Nit's{\c&HFFFFF0&} {\c&HFFF5EE&}a{\c&HFFF5EE&} {\c&HFAEBD7&}mountain{\c&HFAEBD7&} {\c&HFFFAFA&}of{\c&HFFFAFA&} {\c&HCCFFFF&}treasure{\c&HCCFFFF&} {\c&HFFFFFF&}!{\c&HFFFFFF&}
+Dialogue: 0,0:09:13.08,0:09:17.22,Default-ja,,0,0,0,,{\c&HFAFAD2&}わあ{\c&HFAFAD2&}{\c&HFFFACD&}新しい{\c&HFFFACD&}{\c&HFFEFD5&}山{\c&HFFEFD5&}{\c&HFFFFF0&}だ{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}{\c&HFAEBD7&}N{\c&HFAEBD7&}{\c&HFFFAFA&}ワクワク{\c&HFFFAFA&}{\c&HCCFFFF&}ワクワク{\c&HCCFFFF&}{\c&HFFFFFF&}！{\c&HFFFFFF&}
 Dialogue: 0,0:09:13.75,0:09:15.58,Default,,0,0,0,,A new mountain.
 Dialogue: 0,0:09:15.68,0:09:17.34,Default,,0,0,0,,Hurray!
-Dialogue: 0,0:09:18.79,0:09:20.22,Default,,0,0,0,,Hey, wait!
-Dialogue: 0,0:09:18.85,0:09:20.06,Default-ja,,0,0,0,,（圭一）おい 待てよ！
-Dialogue: 0,0:09:20.39,0:09:22.89,Default-ja,,0,0,0,,ウワッ！ いたたた…
-Dialogue: 0,0:09:21.69,0:09:22.78,Default,,0,0,0,,Ow...
-Dialogue: 0,0:09:23.09,0:09:25.72,Default,,0,0,0,,You can just stay there!
-Dialogue: 0,0:09:23.09,0:09:27.70,Default-ja,,0,0,0,,いいよ 圭一君は そこにいて\Nすぐ済むから！
+Dialogue: 0,0:09:18.79,0:09:20.22,Default,,0,0,0,,{\c&HCCFFFF&}Hey{\c&HCCFFFF&} {\c&HCCFFCC&},{\c&HCCFFCC&} {\c&HFFFFCC&}wait{\c&HFFFFCC&} {\c&HFFCCCC&}!{\c&HFFCCCC&}
+Dialogue: 0,0:09:18.85,0:09:20.06,Default-ja,,0,0,0,,{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HCCFFCC&}圭一{\c&HCCFFCC&}{\c&HFFFFCC&}）{\c&HFFFFCC&}{\c&HFFCCCC&}おい{\c&HFFCCCC&}待てよ！
+Dialogue: 0,0:09:20.39,0:09:22.89,Default-ja,,0,0,0,,{\c&HFFCCFF&}ウワッ{\c&HFFCCFF&}{\c&HCCE5FF&}！{\c&HCCE5FF&}いたたた…
+Dialogue: 0,0:09:21.69,0:09:22.78,Default,,0,0,0,,{\c&HFFCCFF&}Ow{\c&HFFCCFF&} {\c&HCCE5FF&}...{\c&HCCE5FF&}
+Dialogue: 0,0:09:23.09,0:09:25.72,Default,,0,0,0,,{\c&HFFD8B1&}You{\c&HFFD8B1&} {\c&HCCE0FF&}can{\c&HCCE0FF&} {\c&HFFFFE0&}just{\c&HFFFFE0&} {\c&HFFF0F5&}stay{\c&HFFF0F5&} {\c&HFFE4E1&}there{\c&HFFE4E1&} {\c&HFAFAD2&}!{\c&HFAFAD2&}
+Dialogue: 0,0:09:23.09,0:09:27.70,Default-ja,,0,0,0,,{\c&HFFD8B1&}いい{\c&HFFD8B1&}{\c&HCCE0FF&}よ{\c&HCCE0FF&}{\c&HFFFFE0&}圭一{\c&HFFFFE0&}{\c&HFFF0F5&}君{\c&HFFF0F5&}{\c&HFFE4E1&}は{\c&HFFE4E1&}{\c&HFAFAD2&}そこ{\c&HFAFAD2&}にいて\Nすぐ済むから！
 Dialogue: 0,0:09:25.83,0:09:27.76,Default,,0,0,0,,I'll be done soon!
-Dialogue: 0,0:09:27.86,0:09:32.13,Default,,0,0,0,,Are all country girls this tough?
-Dialogue: 0,0:09:27.93,0:09:29.90,Default-ja,,0,0,0,,（圭一）さすが田舎育ち…
+Dialogue: 0,0:09:27.86,0:09:32.13,Default,,0,0,0,,{\c&HFFFACD&}Are{\c&HFFFACD&} {\c&HFFEFD5&}all{\c&HFFEFD5&} {\c&HFFFFF0&}country{\c&HFFFFF0&} {\c&HFFF5EE&}girls{\c&HFFF5EE&} {\c&HFAEBD7&}this{\c&HFAEBD7&} {\c&HFFFAFA&}tough{\c&HFFFAFA&} {\c&HCCFFFF&}?{\c&HCCFFFF&}
+Dialogue: 0,0:09:27.93,0:09:29.90,Default-ja,,0,0,0,,{\c&HFFFACD&}（{\c&HFFFACD&}{\c&HFFEFD5&}圭一{\c&HFFEFD5&}{\c&HFFFFF0&}）{\c&HFFFFF0&}{\c&HFFF5EE&}さすが{\c&HFFF5EE&}{\c&HFAEBD7&}田舎{\c&HFAEBD7&}{\c&HFFFAFA&}育ち{\c&HFFFAFA&}{\c&HCCFFFF&}…{\c&HCCFFFF&}
 Dialogue: 0,0:09:31.07,0:09:32.23,Default-ja,,0,0,0,,かなわん
 Dialogue: 0,0:09:33.40,0:09:35.04,Default-ja,,0,0,0,,（圭一）ハァ…
 Dialogue: 0,0:09:40.44,0:09:41.91,Default-ja,,0,0,0,,うん？\N（富竹(とみたけ)）あっ…
 Dialogue: 0,0:09:42.24,0:09:43.91,Default-ja,,0,0,0,,ンンッ！ ハァ…
-Dialogue: 0,0:09:44.48,0:09:45.98,Default-ja,,0,0,0,,（富竹）ああ びっくりした
-Dialogue: 0,0:09:44.61,0:09:45.98,Default,,0,0,0,,You surprised me.
-Dialogue: 0,0:09:46.08,0:09:48.81,Default,,0,0,0,,T-That's my line!
-Dialogue: 0,0:09:46.11,0:09:48.82,Default-ja,,0,0,0,,（圭一）\Nそ… それは こっちのセリフだよ
-Dialogue: 0,0:09:48.92,0:09:52.85,Default-ja,,0,0,0,,（富竹）あっ ごめんごめん\N驚かすつもりはなかったんだ
-Dialogue: 0,0:09:49.12,0:09:53.21,Default,,0,0,0,,Sorry, I didn't mean to scare you.
-Dialogue: 0,0:09:53.25,0:09:57.19,Default-ja,,0,0,0,,君は雛見沢の人かい？\N（圭一）は… はぁ…
-Dialogue: 0,0:09:53.32,0:09:55.65,Default,,0,0,0,,Are you from Hinamizawa?
-Dialogue: 0,0:09:55.76,0:09:57.42,Default,,0,0,0,,Y-Yes...
-Dialogue: 0,0:09:57.43,0:10:00.90,Default-ja,,0,0,0,,僕は富竹　フリーのカメラマン
+Dialogue: 0,0:09:44.48,0:09:45.98,Default-ja,,0,0,0,,{\c&HFFFFFF&}（{\c&HFFFFFF&}{\c&HCCFFFF&}富竹{\c&HCCFFFF&}{\c&HCCFFCC&}）{\c&HCCFFCC&}{\c&HFFFFCC&}ああ{\c&HFFFFCC&}びっくりした
+Dialogue: 0,0:09:44.61,0:09:45.98,Default,,0,0,0,,{\c&HFFFFFF&}You{\c&HFFFFFF&} {\c&HCCFFFF&}surprised{\c&HCCFFFF&} {\c&HCCFFCC&}me{\c&HCCFFCC&} {\c&HFFFFCC&}.{\c&HFFFFCC&}
+Dialogue: 0,0:09:46.08,0:09:48.81,Default,,0,0,0,,{\c&HFFCCCC&}T{\c&HFFCCCC&} {\c&HFFCCFF&}-{\c&HFFCCFF&} {\c&HCCE5FF&}That's{\c&HCCE5FF&} {\c&HFFD8B1&}my{\c&HFFD8B1&} {\c&HCCE0FF&}line{\c&HCCE0FF&} {\c&HFFFFE0&}!{\c&HFFFFE0&}
+Dialogue: 0,0:09:46.11,0:09:48.82,Default-ja,,0,0,0,,{\c&HFFCCCC&}（{\c&HFFCCCC&}{\c&HFFCCFF&}圭一{\c&HFFCCFF&}{\c&HCCE5FF&}）{\c&HCCE5FF&}{\c&HFFD8B1&}\{\c&HFFD8B1&}{\c&HCCE0FF&}N{\c&HCCE0FF&}{\c&HFFFFE0&}そ{\c&HFFFFE0&}…それはこっちのセリフだよ
+Dialogue: 0,0:09:48.92,0:09:52.85,Default-ja,,0,0,0,,{\c&HFFF0F5&}（{\c&HFFF0F5&}{\c&HFFE4E1&}富竹{\c&HFFE4E1&}{\c&HFAFAD2&}）{\c&HFAFAD2&}{\c&HFFFACD&}あっ{\c&HFFFACD&}{\c&HFFEFD5&}ごめん{\c&HFFEFD5&}{\c&HFFFFF0&}ごめん{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}{\c&HFAEBD7&}N{\c&HFAEBD7&}{\c&HFFFAFA&}驚かす{\c&HFFFAFA&}つもりはなかったんだ
+Dialogue: 0,0:09:49.12,0:09:53.21,Default,,0,0,0,,{\c&HFFF0F5&}Sorry{\c&HFFF0F5&} {\c&HFFE4E1&},{\c&HFFE4E1&} {\c&HFAFAD2&}I{\c&HFAFAD2&} {\c&HFFFACD&}didn't{\c&HFFFACD&} {\c&HFFEFD5&}mean{\c&HFFEFD5&} {\c&HFFFFF0&}to{\c&HFFFFF0&} {\c&HFFF5EE&}scare{\c&HFFF5EE&} {\c&HFAEBD7&}you{\c&HFAEBD7&} {\c&HFFFAFA&}.{\c&HFFFAFA&}
+Dialogue: 0,0:09:53.25,0:09:57.19,Default-ja,,0,0,0,,{\c&HCCFFFF&}君{\c&HCCFFFF&}{\c&HFFFFFF&}は{\c&HFFFFFF&}{\c&HCCFFFF&}雛{\c&HCCFFFF&}{\c&HCCFFCC&}見沢{\c&HCCFFCC&}{\c&HFFFFCC&}の{\c&HFFFFCC&}人かい？\N（圭一）は…はぁ…
+Dialogue: 0,0:09:53.32,0:09:55.65,Default,,0,0,0,,{\c&HCCFFFF&}Are{\c&HCCFFFF&} {\c&HFFFFFF&}you{\c&HFFFFFF&} {\c&HCCFFFF&}from{\c&HCCFFFF&} {\c&HCCFFCC&}Hinamizawa{\c&HCCFFCC&} {\c&HFFFFCC&}?{\c&HFFFFCC&}
+Dialogue: 0,0:09:55.76,0:09:57.42,Default,,0,0,0,,{\c&HFFCCCC&}Y{\c&HFFCCCC&} {\c&HFFCCFF&}-{\c&HFFCCFF&} {\c&HCCE5FF&}Yes{\c&HCCE5FF&} {\c&HFFD8B1&}...{\c&HFFD8B1&}
+Dialogue: 0,0:09:57.43,0:10:00.90,Default-ja,,0,0,0,,{\c&HFFCCCC&}僕{\c&HFFCCCC&}{\c&HFFCCFF&}は{\c&HFFCCFF&}{\c&HCCE5FF&}富竹{\c&HCCE5FF&}{\c&HFFD8B1&}　{\c&HFFD8B1&}フリーのカメラマン
 Dialogue: 0,0:09:57.53,0:10:01.02,Default,,0,0,0,,I'm Tomitake,\Na freelance photographer.
-Dialogue: 0,0:10:01.13,0:10:03.93,Default,,0,0,0,,I occasionally\Ncome to Hinamizawa.
-Dialogue: 0,0:10:01.13,0:10:03.80,Default-ja,,0,0,0,,この雛見沢には たまに来るんだ
-Dialogue: 0,0:10:04.03,0:10:09.30,Default,,0,0,0,,Isn't it polite to ask permission\Nbefore taking a picture?
-Dialogue: 0,0:10:04.03,0:10:05.33,Default-ja,,0,0,0,,（圭一）写真ってのは―
+Dialogue: 0,0:10:01.13,0:10:03.93,Default,,0,0,0,,{\c&HCCE0FF&}I{\c&HCCE0FF&} {\c&HFFFFE0&}occasionally{\c&HFFFFE0&} {\c&HFFF0F5&}\{\c&HFFF0F5&} {\c&HFFE4E1&}Ncome{\c&HFFE4E1&} {\c&HFAFAD2&}to{\c&HFAFAD2&} {\c&HFFFACD&}Hinamizawa{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:10:01.13,0:10:03.80,Default-ja,,0,0,0,,{\c&HCCE0FF&}この{\c&HCCE0FF&}{\c&HFFFFE0&}雛{\c&HFFFFE0&}{\c&HFFF0F5&}見沢{\c&HFFF0F5&}{\c&HFFE4E1&}に{\c&HFFE4E1&}{\c&HFAFAD2&}は{\c&HFAFAD2&}{\c&HFFFACD&}たま{\c&HFFFACD&}{\c&HFFEFD5&}に{\c&HFFEFD5&}来るんだ
+Dialogue: 0,0:10:04.03,0:10:09.30,Default,,0,0,0,,{\c&HFFFFF0&}Isn't{\c&HFFFFF0&} {\c&HFFF5EE&}it{\c&HFFF5EE&} {\c&HFAEBD7&}polite{\c&HFAEBD7&} {\c&HFFFAFA&}to{\c&HFFFAFA&} {\c&HCCFFFF&}ask{\c&HCCFFFF&} {\c&HFFFFFF&}permission{\c&HFFFFFF&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HCCFFCC&}Nbefore{\c&HCCFFCC&} taking a picture ?
+Dialogue: 0,0:10:04.03,0:10:05.33,Default-ja,,0,0,0,,{\c&HFFFFF0&}（{\c&HFFFFF0&}{\c&HFFF5EE&}圭一{\c&HFFF5EE&}{\c&HFAEBD7&}）{\c&HFAEBD7&}{\c&HFFFAFA&}写真{\c&HFFFAFA&}{\c&HCCFFFF&}って{\c&HCCFFFF&}{\c&HFFFFFF&}の{\c&HFFFFFF&}{\c&HCCFFFF&}は{\c&HCCFFFF&}{\c&HCCFFCC&}―{\c&HCCFFCC&}
 Dialogue: 0,0:10:05.43,0:10:08.37,Default-ja,,0,0,0,,被写体に断ってから撮るのが\N礼儀なんじゃないんスかね？
-Dialogue: 0,0:10:09.14,0:10:12.84,Default-ja,,0,0,0,,あっ ごめんごめん\Nメーンは野鳥の撮影でね
-Dialogue: 0,0:10:09.40,0:10:12.80,Default,,0,0,0,,Sorry, I usually take\Npictures of wild birds.
-Dialogue: 0,0:10:12.91,0:10:15.38,Default,,0,0,0,,I've never asked them before.
-Dialogue: 0,0:10:12.94,0:10:16.01,Default-ja,,0,0,0,,今まで断ったためしがないんだよ\Nハハハハッ…
-Dialogue: 0,0:10:18.11,0:10:20.42,Default-ja,,0,0,0,,ハハッ… あっ いや…\N（ﾚﾅ）圭一君！
-Dialogue: 0,0:10:18.91,0:10:20.97,Default,,0,0,0,,Keiichi-kun!
-Dialogue: 0,0:10:21.72,0:10:25.98,Default,,0,0,0,,Sorry for making you wait!\NI'm almost done!
-Dialogue: 0,0:10:21.78,0:10:25.89,Default-ja,,0,0,0,,（ﾚﾅ）待たせて ごめんね\Nもう終わりにするから
-Dialogue: 0,0:10:26.09,0:10:27.92,Default,,0,0,0,,You had company?
-Dialogue: 0,0:10:26.12,0:10:27.89,Default-ja,,0,0,0,,（富竹）連れがいたのかい？
-Dialogue: 0,0:10:28.22,0:10:31.53,Default-ja,,0,0,0,,彼女は\Nあんな所で何をしているんだい？
-Dialogue: 0,0:10:28.29,0:10:31.26,Default,,0,0,0,,What's she doing there?
-Dialogue: 0,0:10:31.76,0:10:33.23,Default,,0,0,0,,Who knows?
-Dialogue: 0,0:10:31.83,0:10:33.09,Default-ja,,0,0,0,,さあね？
-Dialogue: 0,0:10:33.36,0:10:37.20,Default-ja,,0,0,0,,昔 殺して埋めたバラバラ死体でも\N確認してるんじゃないッスか？
-Dialogue: 0,0:10:33.46,0:10:37.92,Default,,0,0,0,,Maybe she's checking out\Nan old corpse she chopped up.
-Dialogue: 0,0:10:41.00,0:10:42.90,Default-ja,,0,0,0,,（富竹）イヤな事件だったね
-Dialogue: 0,0:10:41.00,0:10:43.20,Default,,0,0,0,,It was a horrible crime.
-Dialogue: 0,0:10:43.27,0:10:46.07,Default-ja,,0,0,0,,腕が１本\Nまだ見つかってないんだろう？
-Dialogue: 0,0:10:43.30,0:10:47.10,Default,,0,0,0,,They still haven't found\None of the arms, right?
-Dialogue: 0,0:10:47.11,0:10:50.51,Default-ja,,0,0,0,,えっ？ 何の…
-Dialogue: 0,0:10:48.81,0:10:50.44,Default,,0,0,0,,What...
-Dialogue: 0,0:10:51.45,0:10:54.48,Default-ja,,0,0,0,,（ﾚﾅ）\Nアハハッ！ 圭一君 お待たせ！
-Dialogue: 0,0:10:53.01,0:10:55.51,Default,,0,0,0,,Thanks for waiting, Keiichi-kun!
-Dialogue: 0,0:10:55.52,0:10:59.12,Default-ja,,0,0,0,,じゃ\N馬に蹴られる前に退散するかな
-Dialogue: 0,0:10:55.62,0:10:59.14,Default,,0,0,0,,Well, I should go\Nbefore I get kicked out.
-Dialogue: 0,0:10:59.22,0:11:02.49,Default-ja,,0,0,0,,驚かせて すまなかったね 圭一君
-Dialogue: 0,0:10:59.25,0:11:02.52,Default,,0,0,0,,Sorry for scaring you, Keiichi-kun.
-Dialogue: 0,0:11:08.43,0:11:10.53,Default-ja,,0,0,0,,（ﾚﾅ）待ったかな？ かな？
-Dialogue: 0,0:11:08.50,0:11:10.76,Default,,0,0,0,,Did you wait? Did you?
-Dialogue: 0,0:11:13.80,0:11:15.33,Default,,0,0,0,,Keiichi-kun?
-Dialogue: 0,0:11:13.84,0:11:14.50,Default-ja,,0,0,0,,圭一君？
-Dialogue: 0,0:11:14.90,0:11:18.31,Default-ja,,0,0,0,,えっ？\Nあっ …で どうだったんだ？
-Dialogue: 0,0:11:16.54,0:11:18.27,Default,,0,0,0,,How did it go?
-Dialogue: 0,0:11:18.84,0:11:20.90,Default,,0,0,0,,Did you find anything?
-Dialogue: 0,0:11:18.87,0:11:21.01,Default-ja,,0,0,0,,（圭一）\N掘り出し物は見つかったか？
-Dialogue: 0,0:11:21.41,0:11:26.51,Default-ja,,0,0,0,,うん！ 聞いて聞いて\Nあのね あったの ケンタくん人形！
-Dialogue: 0,0:11:22.24,0:11:26.54,Default,,0,0,0,,Listen, listen!\NI found a Kenta doll!
-Dialogue: 0,0:11:26.98,0:11:28.54,Default,,0,0,0,,A Kenta doll?
-Dialogue: 0,0:11:27.02,0:11:30.15,Default-ja,,0,0,0,,ケンタくん人形って… あれか？
-Dialogue: 0,0:11:28.65,0:11:30.34,Default,,0,0,0,,You mean that?
-Dialogue: 0,0:11:30.42,0:11:34.12,Default-ja,,0,0,0,,“ケンタくんフライドチキン”の\N店の前に必ず置いてある―
-Dialogue: 0,0:11:30.45,0:11:36.05,Default,,0,0,0,,That life-sized model that's always\Noutside Kenta Fried Chicken?
-Dialogue: 0,0:11:34.22,0:11:36.22,Default-ja,,0,0,0,,あの等身大人形の？
-Dialogue: 0,0:11:38.13,0:11:40.25,Default,,0,0,0,,Yeah, the Kenta doll!
-Dialogue: 0,0:11:38.16,0:11:39.83,Default-ja,,0,0,0,,そう ケンタくん！
-Dialogue: 0,0:11:39.93,0:11:43.46,Default-ja,,0,0,0,,はぅ… かぁいいよ\Nお持ち帰りしたい！
-Dialogue: 0,0:11:40.36,0:11:43.46,Default,,0,0,0,,It's so cute!\NI want to take him home!
-Dialogue: 0,0:11:43.93,0:11:46.30,Default-ja,,0,0,0,,フフッ… あれはゴミだろう
-Dialogue: 0,0:11:45.00,0:11:46.43,Default,,0,0,0,,That's trash, right?
-Dialogue: 0,0:11:46.47,0:11:49.14,Default-ja,,0,0,0,,お持ち帰りしたきゃ\Nしてもいいんだぜ
-Dialogue: 0,0:11:46.53,0:11:49.87,Default,,0,0,0,,If you want to take it,\NI'm sure you could.
-Dialogue: 0,0:11:49.97,0:11:54.27,Default,,0,0,0,,The Kenta doll is trapped\Nunder a pile of junk.
-Dialogue: 0,0:11:50.00,0:11:54.14,Default-ja,,0,0,0,,ケンタくん\Nゴミの山の下敷きになってるの
-Dialogue: 0,0:11:54.34,0:11:56.54,Default-ja,,0,0,0,,簡単には掘り出せないよ
-Dialogue: 0,0:11:54.38,0:11:56.84,Default,,0,0,0,,I can't easily dig him out.
-Dialogue: 0,0:11:56.94,0:11:59.31,Default,,0,0,0,,I'll help you tomorrow.
-Dialogue: 0,0:11:56.98,0:12:00.08,Default-ja,,0,0,0,,あした 俺も手伝ってやるよ\N（ﾚﾅ）えっ？
-Dialogue: 0,0:12:00.45,0:12:02.55,Default-ja,,0,0,0,,弁当の恩返しってことでさ
-Dialogue: 0,0:12:00.51,0:12:02.57,Default,,0,0,0,,In exchange for lunch today.
-Dialogue: 0,0:12:02.92,0:12:05.05,Default-ja,,0,0,0,,あ… ありがとう
-Dialogue: 0,0:12:03.58,0:12:05.02,Default,,0,0,0,,Thanks!
-Dialogue: 0,0:12:05.12,0:12:07.49,Default,,0,0,0,,Keiichi-kun will help...
-Dialogue: 0,0:12:05.15,0:12:07.39,Default-ja,,0,0,0,,圭一君が手伝ってくれる…
-Dialogue: 0,0:12:07.49,0:12:10.23,Default-ja,,0,0,0,,ケンタくんをお持ち帰りできる！
-Dialogue: 0,0:12:07.59,0:12:11.32,Default,,0,0,0,,I'll get to take\Nthe Kenta doll home!
-Dialogue: 0,0:12:12.76,0:12:16.20,Default,,0,0,0,,Hey, Rena, did something\Nhappen here in the past?
-Dialogue: 0,0:12:12.89,0:12:16.23,Default-ja,,0,0,0,,なあ レナ\Nここで昔 何かあったのか？
-Dialogue: 0,0:12:16.36,0:12:19.63,Default-ja,,0,0,0,,あっ…\Nダムの工事をやってたんだって
-Dialogue: 0,0:12:17.10,0:12:19.93,Default,,0,0,0,,I heard they were building a dam.
-Dialogue: 0,0:12:20.03,0:12:22.76,Default,,0,0,0,,I don't know too much about it.
-Dialogue: 0,0:12:20.07,0:12:22.24,Default-ja,,0,0,0,,詳しくは知らないけど
-Dialogue: 0,0:12:22.87,0:12:25.13,Default,,0,0,0,,They were building a dam?
-Dialogue: 0,0:12:22.94,0:12:24.24,Default-ja,,0,0,0,,ダムの工事？
-Dialogue: 0,0:12:25.21,0:12:29.24,Default-ja,,0,0,0,,例えばさ\Nその工事中に何かあったとか
-Dialogue: 0,0:12:25.24,0:12:30.23,Default,,0,0,0,,Did something happen during\Nconstruction, like an accident?
-Dialogue: 0,0:12:29.44,0:12:30.31,Default-ja,,0,0,0,,事故とか…
-Dialogue: 0,0:12:30.34,0:12:31.83,Default,,0,0,0,,I don't know.
+Dialogue: 0,0:10:09.14,0:10:12.84,Default-ja,,0,0,0,,{\c&HFFFFCC&}あっ{\c&HFFFFCC&}{\c&HFFCCCC&}ごめん{\c&HFFCCCC&}{\c&HFFCCFF&}ごめん{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}メーン{\c&HCCE0FF&}{\c&HFFFFE0&}は{\c&HFFFFE0&}{\c&HFFF0F5&}野鳥{\c&HFFF0F5&}{\c&HFFE4E1&}の{\c&HFFE4E1&}{\c&HFAFAD2&}撮影{\c&HFAFAD2&}{\c&HFFFACD&}で{\c&HFFFACD&}ね
+Dialogue: 0,0:10:09.40,0:10:12.80,Default,,0,0,0,,{\c&HFFFFCC&}Sorry{\c&HFFFFCC&} {\c&HFFCCCC&},{\c&HFFCCCC&} {\c&HFFCCFF&}I{\c&HFFCCFF&} {\c&HCCE5FF&}usually{\c&HCCE5FF&} {\c&HFFD8B1&}take{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}Npictures{\c&HFFFFE0&} {\c&HFFF0F5&}of{\c&HFFF0F5&} {\c&HFFE4E1&}wild{\c&HFFE4E1&} {\c&HFAFAD2&}birds{\c&HFAFAD2&} {\c&HFFFACD&}.{\c&HFFFACD&}
+Dialogue: 0,0:10:12.91,0:10:15.38,Default,,0,0,0,,{\c&HFFEFD5&}I've{\c&HFFEFD5&} {\c&HFFFFF0&}never{\c&HFFFFF0&} {\c&HFFF5EE&}asked{\c&HFFF5EE&} {\c&HFAEBD7&}them{\c&HFAEBD7&} {\c&HFFFAFA&}before{\c&HFFFAFA&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:10:12.94,0:10:16.01,Default-ja,,0,0,0,,{\c&HFFEFD5&}今{\c&HFFEFD5&}{\c&HFFFFF0&}まで{\c&HFFFFF0&}{\c&HFFF5EE&}断っ{\c&HFFF5EE&}{\c&HFAEBD7&}た{\c&HFAEBD7&}{\c&HFFFAFA&}ため{\c&HFFFAFA&}{\c&HCCFFFF&}しがない{\c&HCCFFFF&}んだよ\Nハハハハッ…
+Dialogue: 0,0:10:18.11,0:10:20.42,Default-ja,,0,0,0,,{\c&HFFFFFF&}ハハッ{\c&HFFFFFF&}{\c&HCCFFFF&}…{\c&HCCFFFF&}{\c&HCCFFCC&}あっ{\c&HCCFFCC&}{\c&HFFFFCC&}いや{\c&HFFFFCC&}…\N（ﾚﾅ）圭一君！
+Dialogue: 0,0:10:18.91,0:10:20.97,Default,,0,0,0,,{\c&HFFFFFF&}Keiichi{\c&HFFFFFF&} {\c&HCCFFFF&}-{\c&HCCFFFF&} {\c&HCCFFCC&}kun{\c&HCCFFCC&} {\c&HFFFFCC&}!{\c&HFFFFCC&}
+Dialogue: 0,0:10:21.72,0:10:25.98,Default,,0,0,0,,{\c&HFFCCCC&}Sorry{\c&HFFCCCC&} {\c&HFFCCFF&}for{\c&HFFCCFF&} {\c&HCCE5FF&}making{\c&HCCE5FF&} {\c&HFFD8B1&}you{\c&HFFD8B1&} {\c&HCCE0FF&}wait{\c&HCCE0FF&} {\c&HFFFFE0&}!\{\c&HFFFFE0&} {\c&HFFF0F5&}NI'm{\c&HFFF0F5&} {\c&HFFE4E1&}almost{\c&HFFE4E1&} {\c&HFAFAD2&}done{\c&HFAFAD2&} {\c&HFFFACD&}!{\c&HFFFACD&}
+Dialogue: 0,0:10:21.78,0:10:25.89,Default-ja,,0,0,0,,{\c&HFFCCCC&}（{\c&HFFCCCC&}{\c&HFFCCFF&}ﾚﾅ{\c&HFFCCFF&}{\c&HCCE5FF&}）{\c&HCCE5FF&}{\c&HFFD8B1&}待た{\c&HFFD8B1&}{\c&HCCE0FF&}せ{\c&HCCE0FF&}{\c&HFFFFE0&}て{\c&HFFFFE0&}{\c&HFFF0F5&}ごめん{\c&HFFF0F5&}{\c&HFFE4E1&}ね{\c&HFFE4E1&}{\c&HFAFAD2&}\{\c&HFAFAD2&}{\c&HFFFACD&}N{\c&HFFFACD&}もう終わりにするから
+Dialogue: 0,0:10:26.09,0:10:27.92,Default,,0,0,0,,{\c&HFFEFD5&}You{\c&HFFEFD5&} {\c&HFFFFF0&}had{\c&HFFFFF0&} {\c&HFFF5EE&}company{\c&HFFF5EE&} {\c&HFAEBD7&}?{\c&HFAEBD7&}
+Dialogue: 0,0:10:26.12,0:10:27.89,Default-ja,,0,0,0,,{\c&HFFEFD5&}（{\c&HFFEFD5&}{\c&HFFFFF0&}富竹{\c&HFFFFF0&}{\c&HFFF5EE&}）{\c&HFFF5EE&}{\c&HFAEBD7&}連れ{\c&HFAEBD7&}がいたのかい？
+Dialogue: 0,0:10:28.22,0:10:31.53,Default-ja,,0,0,0,,{\c&HFFFAFA&}彼女{\c&HFFFAFA&}{\c&HCCFFFF&}は{\c&HCCFFFF&}{\c&HFFFFFF&}\{\c&HFFFFFF&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HCCFFCC&}あんな{\c&HCCFFCC&}所で何をしているんだい？
+Dialogue: 0,0:10:28.29,0:10:31.26,Default,,0,0,0,,{\c&HFFFAFA&}What's{\c&HFFFAFA&} {\c&HCCFFFF&}she{\c&HCCFFFF&} {\c&HFFFFFF&}doing{\c&HFFFFFF&} {\c&HCCFFFF&}there{\c&HCCFFFF&} {\c&HCCFFCC&}?{\c&HCCFFCC&}
+Dialogue: 0,0:10:31.76,0:10:33.23,Default,,0,0,0,,{\c&HFFFFCC&}Who{\c&HFFFFCC&} {\c&HFFCCCC&}knows{\c&HFFCCCC&} {\c&HFFCCFF&}?{\c&HFFCCFF&}
+Dialogue: 0,0:10:31.83,0:10:33.09,Default-ja,,0,0,0,,{\c&HFFFFCC&}さあ{\c&HFFFFCC&}{\c&HFFCCCC&}ね{\c&HFFCCCC&}{\c&HFFCCFF&}？{\c&HFFCCFF&}
+Dialogue: 0,0:10:33.36,0:10:37.20,Default-ja,,0,0,0,,{\c&HCCE5FF&}昔{\c&HCCE5FF&}{\c&HFFD8B1&}殺し{\c&HFFD8B1&}{\c&HCCE0FF&}て{\c&HCCE0FF&}{\c&HFFFFE0&}埋め{\c&HFFFFE0&}{\c&HFFF0F5&}た{\c&HFFF0F5&}{\c&HFFE4E1&}バラバラ{\c&HFFE4E1&}{\c&HFAFAD2&}死体{\c&HFAFAD2&}{\c&HFFFACD&}で{\c&HFFFACD&}{\c&HFFEFD5&}も{\c&HFFEFD5&}{\c&HFFFFF0&}\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}{\c&HFAEBD7&}確認{\c&HFAEBD7&}してるんじゃないッスか？
+Dialogue: 0,0:10:33.46,0:10:37.92,Default,,0,0,0,,{\c&HCCE5FF&}Maybe{\c&HCCE5FF&} {\c&HFFD8B1&}she's{\c&HFFD8B1&} {\c&HCCE0FF&}checking{\c&HCCE0FF&} {\c&HFFFFE0&}out{\c&HFFFFE0&} {\c&HFFF0F5&}\{\c&HFFF0F5&} {\c&HFFE4E1&}Nan{\c&HFFE4E1&} {\c&HFAFAD2&}old{\c&HFAFAD2&} {\c&HFFFACD&}corpse{\c&HFFFACD&} {\c&HFFEFD5&}she{\c&HFFEFD5&} {\c&HFFFFF0&}chopped{\c&HFFFFF0&} {\c&HFFF5EE&}up{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:10:41.00,0:10:42.90,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}富竹{\c&HCCFFFF&}{\c&HFFFFFF&}）{\c&HFFFFFF&}{\c&HCCFFFF&}イヤ{\c&HCCFFFF&}{\c&HCCFFCC&}な{\c&HCCFFCC&}{\c&HFFFFCC&}事件{\c&HFFFFCC&}だったね
+Dialogue: 0,0:10:41.00,0:10:43.20,Default,,0,0,0,,{\c&HFFFAFA&}It{\c&HFFFAFA&} {\c&HCCFFFF&}was{\c&HCCFFFF&} {\c&HFFFFFF&}a{\c&HFFFFFF&} {\c&HCCFFFF&}horrible{\c&HCCFFFF&} {\c&HCCFFCC&}crime{\c&HCCFFCC&} {\c&HFFFFCC&}.{\c&HFFFFCC&}
+Dialogue: 0,0:10:43.27,0:10:46.07,Default-ja,,0,0,0,,{\c&HFFCCCC&}腕{\c&HFFCCCC&}{\c&HFFCCFF&}が{\c&HFFCCFF&}{\c&HCCE5FF&}１{\c&HCCE5FF&}{\c&HFFD8B1&}本{\c&HFFD8B1&}{\c&HCCE0FF&}\{\c&HCCE0FF&}{\c&HFFFFE0&}N{\c&HFFFFE0&}{\c&HFFF0F5&}まだ{\c&HFFF0F5&}{\c&HFFE4E1&}見つかっ{\c&HFFE4E1&}{\c&HFAFAD2&}て{\c&HFAFAD2&}{\c&HFFFACD&}ない{\c&HFFFACD&}{\c&HFFEFD5&}ん{\c&HFFEFD5&}{\c&HFFFFF0&}だろ{\c&HFFFFF0&}う？
+Dialogue: 0,0:10:43.30,0:10:47.10,Default,,0,0,0,,{\c&HFFCCCC&}They{\c&HFFCCCC&} {\c&HFFCCFF&}still{\c&HFFCCFF&} {\c&HCCE5FF&}haven't{\c&HCCE5FF&} {\c&HFFD8B1&}found{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}None{\c&HFFFFE0&} {\c&HFFF0F5&}of{\c&HFFF0F5&} {\c&HFFE4E1&}the{\c&HFFE4E1&} {\c&HFAFAD2&}arms{\c&HFAFAD2&} {\c&HFFFACD&},{\c&HFFFACD&} {\c&HFFEFD5&}right{\c&HFFEFD5&} {\c&HFFFFF0&}?{\c&HFFFFF0&}
+Dialogue: 0,0:10:47.11,0:10:50.51,Default-ja,,0,0,0,,{\c&HFFF5EE&}えっ{\c&HFFF5EE&}{\c&HFAEBD7&}？{\c&HFAEBD7&}何の…
+Dialogue: 0,0:10:48.81,0:10:50.44,Default,,0,0,0,,{\c&HFFF5EE&}What{\c&HFFF5EE&} {\c&HFAEBD7&}...{\c&HFAEBD7&}
+Dialogue: 0,0:10:51.45,0:10:54.48,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}ﾚﾅ{\c&HCCFFFF&}{\c&HFFFFFF&}）\{\c&HFFFFFF&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HCCFFCC&}アハハッ{\c&HCCFFCC&}{\c&HFFFFCC&}！{\c&HFFFFCC&}{\c&HFFCCCC&}圭一{\c&HFFCCCC&}{\c&HFFCCFF&}君{\c&HFFCCFF&}お待たせ！
+Dialogue: 0,0:10:53.01,0:10:55.51,Default,,0,0,0,,{\c&HFFFAFA&}Thanks{\c&HFFFAFA&} {\c&HCCFFFF&}for{\c&HCCFFFF&} {\c&HFFFFFF&}waiting{\c&HFFFFFF&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HCCFFCC&}Keiichi{\c&HCCFFCC&} {\c&HFFFFCC&}-{\c&HFFFFCC&} {\c&HFFCCCC&}kun{\c&HFFCCCC&} {\c&HFFCCFF&}!{\c&HFFCCFF&}
+Dialogue: 0,0:10:55.52,0:10:59.12,Default-ja,,0,0,0,,{\c&HCCE5FF&}じゃ{\c&HCCE5FF&}{\c&HFFD8B1&}\{\c&HFFD8B1&}{\c&HCCE0FF&}N{\c&HCCE0FF&}{\c&HFFFFE0&}馬{\c&HFFFFE0&}{\c&HFFF0F5&}に{\c&HFFF0F5&}{\c&HFFE4E1&}蹴ら{\c&HFFE4E1&}{\c&HFAFAD2&}れる{\c&HFAFAD2&}{\c&HFFFACD&}前{\c&HFFFACD&}{\c&HFFEFD5&}に{\c&HFFEFD5&}{\c&HFFFFF0&}退散{\c&HFFFFF0&}{\c&HFFF5EE&}する{\c&HFFF5EE&}{\c&HFAEBD7&}か{\c&HFAEBD7&}な
+Dialogue: 0,0:10:55.62,0:10:59.14,Default,,0,0,0,,{\c&HCCE5FF&}Well{\c&HCCE5FF&} {\c&HFFD8B1&},{\c&HFFD8B1&} {\c&HCCE0FF&}I{\c&HCCE0FF&} {\c&HFFFFE0&}should{\c&HFFFFE0&} {\c&HFFF0F5&}go{\c&HFFF0F5&} {\c&HFFE4E1&}\{\c&HFFE4E1&} {\c&HFAFAD2&}Nbefore{\c&HFAFAD2&} {\c&HFFFACD&}I{\c&HFFFACD&} {\c&HFFEFD5&}get{\c&HFFEFD5&} {\c&HFFFFF0&}kicked{\c&HFFFFF0&} {\c&HFFF5EE&}out{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:10:59.22,0:11:02.49,Default-ja,,0,0,0,,{\c&HFFFAFA&}驚か{\c&HFFFAFA&}{\c&HCCFFFF&}せ{\c&HCCFFFF&}{\c&HFFFFFF&}て{\c&HFFFFFF&}{\c&HCCFFFF&}すま{\c&HCCFFFF&}{\c&HCCFFCC&}なかっ{\c&HCCFFCC&}{\c&HFFFFCC&}た{\c&HFFFFCC&}{\c&HFFCCCC&}ね{\c&HFFCCCC&}{\c&HFFCCFF&}圭一{\c&HFFCCFF&}{\c&HCCE5FF&}君{\c&HCCE5FF&}
+Dialogue: 0,0:10:59.25,0:11:02.52,Default,,0,0,0,,{\c&HFFFAFA&}Sorry{\c&HFFFAFA&} {\c&HCCFFFF&}for{\c&HCCFFFF&} {\c&HFFFFFF&}scaring{\c&HFFFFFF&} {\c&HCCFFFF&}you{\c&HCCFFFF&} {\c&HCCFFCC&},{\c&HCCFFCC&} {\c&HFFFFCC&}Keiichi{\c&HFFFFCC&} {\c&HFFCCCC&}-{\c&HFFCCCC&} {\c&HFFCCFF&}kun{\c&HFFCCFF&} {\c&HCCE5FF&}.{\c&HCCE5FF&}
+Dialogue: 0,0:11:08.43,0:11:10.53,Default-ja,,0,0,0,,{\c&HFFD8B1&}（{\c&HFFD8B1&}{\c&HCCE0FF&}ﾚﾅ{\c&HCCE0FF&}{\c&HFFFFE0&}）{\c&HFFFFE0&}{\c&HFFF0F5&}待っ{\c&HFFF0F5&}{\c&HFFE4E1&}た{\c&HFFE4E1&}{\c&HFAFAD2&}か{\c&HFAFAD2&}{\c&HFFFACD&}な{\c&HFFFACD&}？かな？
+Dialogue: 0,0:11:08.50,0:11:10.76,Default,,0,0,0,,{\c&HFFD8B1&}Did{\c&HFFD8B1&} {\c&HCCE0FF&}you{\c&HCCE0FF&} {\c&HFFFFE0&}wait{\c&HFFFFE0&} {\c&HFFF0F5&}?{\c&HFFF0F5&} {\c&HFFE4E1&}Did{\c&HFFE4E1&} {\c&HFAFAD2&}you{\c&HFAFAD2&} {\c&HFFFACD&}?{\c&HFFFACD&}
+Dialogue: 0,0:11:13.80,0:11:15.33,Default,,0,0,0,,{\c&HFFEFD5&}Keiichi{\c&HFFEFD5&} {\c&HFFFFF0&}-{\c&HFFFFF0&} {\c&HFFF5EE&}kun{\c&HFFF5EE&} ?
+Dialogue: 0,0:11:13.84,0:11:14.50,Default-ja,,0,0,0,,{\c&HFFEFD5&}圭一{\c&HFFEFD5&}{\c&HFFFFF0&}君{\c&HFFFFF0&}{\c&HFFF5EE&}？{\c&HFFF5EE&}
+Dialogue: 0,0:11:14.90,0:11:18.31,Default-ja,,0,0,0,,{\c&HFAEBD7&}えっ{\c&HFAEBD7&}{\c&HFFFAFA&}？{\c&HFFFAFA&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}{\c&HCCFFFF&}あっ{\c&HCCFFFF&}…でどうだったんだ？
+Dialogue: 0,0:11:16.54,0:11:18.27,Default,,0,0,0,,{\c&HFAEBD7&}How{\c&HFAEBD7&} {\c&HFFFAFA&}did{\c&HFFFAFA&} {\c&HCCFFFF&}it{\c&HCCFFFF&} {\c&HFFFFFF&}go{\c&HFFFFFF&} {\c&HCCFFFF&}?{\c&HCCFFFF&}
+Dialogue: 0,0:11:18.84,0:11:20.90,Default,,0,0,0,,{\c&HCCFFCC&}Did{\c&HCCFFCC&} {\c&HFFFFCC&}you{\c&HFFFFCC&} {\c&HFFCCCC&}find{\c&HFFCCCC&} {\c&HFFCCFF&}anything{\c&HFFCCFF&} {\c&HCCE5FF&}?{\c&HCCE5FF&}
+Dialogue: 0,0:11:18.87,0:11:21.01,Default-ja,,0,0,0,,{\c&HCCFFCC&}（{\c&HCCFFCC&}{\c&HFFFFCC&}圭一{\c&HFFFFCC&}{\c&HFFCCCC&}）{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}掘り出し物は見つかったか？
+Dialogue: 0,0:11:21.41,0:11:26.51,Default-ja,,0,0,0,,{\c&HFFD8B1&}うん{\c&HFFD8B1&}{\c&HCCE0FF&}！{\c&HCCE0FF&}{\c&HFFFFE0&}聞い{\c&HFFFFE0&}{\c&HFFF0F5&}て{\c&HFFF0F5&}{\c&HFFE4E1&}聞い{\c&HFFE4E1&}{\c&HFAFAD2&}て{\c&HFAFAD2&}{\c&HFFFACD&}\{\c&HFFFACD&}{\c&HFFEFD5&}N{\c&HFFEFD5&}{\c&HFFFFF0&}あの{\c&HFFFFF0&}{\c&HFFF5EE&}ね{\c&HFFF5EE&}あったのケンタくん人形！
+Dialogue: 0,0:11:22.24,0:11:26.54,Default,,0,0,0,,{\c&HFFD8B1&}Listen{\c&HFFD8B1&} {\c&HCCE0FF&},{\c&HCCE0FF&} {\c&HFFFFE0&}listen{\c&HFFFFE0&} {\c&HFFF0F5&}!\{\c&HFFF0F5&} {\c&HFFE4E1&}NI{\c&HFFE4E1&} {\c&HFAFAD2&}found{\c&HFAFAD2&} {\c&HFFFACD&}a{\c&HFFFACD&} {\c&HFFEFD5&}Kenta{\c&HFFEFD5&} {\c&HFFFFF0&}doll{\c&HFFFFF0&} {\c&HFFF5EE&}!{\c&HFFF5EE&}
+Dialogue: 0,0:11:26.98,0:11:28.54,Default,,0,0,0,,{\c&HFAEBD7&}A{\c&HFAEBD7&} {\c&HFFFAFA&}Kenta{\c&HFFFAFA&} {\c&HCCFFFF&}doll{\c&HCCFFFF&} {\c&HFFFFFF&}?{\c&HFFFFFF&}
+Dialogue: 0,0:11:27.02,0:11:30.15,Default-ja,,0,0,0,,{\c&HFAEBD7&}ケンタ{\c&HFAEBD7&}{\c&HFFFAFA&}くん{\c&HFFFAFA&}{\c&HCCFFFF&}人形{\c&HCCFFFF&}{\c&HFFFFFF&}って{\c&HFFFFFF&}…あれか？
+Dialogue: 0,0:11:28.65,0:11:30.34,Default,,0,0,0,,{\c&HCCFFFF&}You{\c&HCCFFFF&} {\c&HCCFFCC&}mean{\c&HCCFFCC&} {\c&HFFFFCC&}that{\c&HFFFFCC&} {\c&HFFCCCC&}?{\c&HFFCCCC&}
+Dialogue: 0,0:11:30.42,0:11:34.12,Default-ja,,0,0,0,,{\c&HCCFFFF&}“{\c&HCCFFFF&}{\c&HCCFFCC&}ケンタ{\c&HCCFFCC&}{\c&HFFFFCC&}くん{\c&HFFFFCC&}{\c&HFFCCCC&}フライドチキン{\c&HFFCCCC&}”の\N店の前に必ず置いてある―
+Dialogue: 0,0:11:30.45,0:11:36.05,Default,,0,0,0,,{\c&HFFCCFF&}That{\c&HFFCCFF&} {\c&HCCE5FF&}life{\c&HCCE5FF&} {\c&HFFD8B1&}-{\c&HFFD8B1&} {\c&HCCE0FF&}sized{\c&HCCE0FF&} {\c&HFFFFE0&}model{\c&HFFFFE0&} {\c&HFFF0F5&}that's{\c&HFFF0F5&} always \ Noutside Kenta Fried Chicken ?
+Dialogue: 0,0:11:34.22,0:11:36.22,Default-ja,,0,0,0,,{\c&HFFCCFF&}あの{\c&HFFCCFF&}{\c&HCCE5FF&}等身{\c&HCCE5FF&}{\c&HFFD8B1&}大人{\c&HFFD8B1&}{\c&HCCE0FF&}形{\c&HCCE0FF&}{\c&HFFFFE0&}の{\c&HFFFFE0&}{\c&HFFF0F5&}？{\c&HFFF0F5&}
+Dialogue: 0,0:11:38.13,0:11:40.25,Default,,0,0,0,,{\c&HFFE4E1&}Yeah{\c&HFFE4E1&} {\c&HFAFAD2&},{\c&HFAFAD2&} {\c&HFFFACD&}the{\c&HFFFACD&} {\c&HFFEFD5&}Kenta{\c&HFFEFD5&} doll !
+Dialogue: 0,0:11:38.16,0:11:39.83,Default-ja,,0,0,0,,{\c&HFFE4E1&}そう{\c&HFFE4E1&}{\c&HFAFAD2&}ケンタ{\c&HFAFAD2&}{\c&HFFFACD&}くん{\c&HFFFACD&}{\c&HFFEFD5&}！{\c&HFFEFD5&}
+Dialogue: 0,0:11:39.93,0:11:43.46,Default-ja,,0,0,0,,{\c&HFFFFF0&}は{\c&HFFFFF0&}{\c&HFFF5EE&}ぅ{\c&HFFF5EE&}{\c&HFAEBD7&}…{\c&HFAEBD7&}{\c&HFFFAFA&}かぁ{\c&HFFFAFA&}{\c&HCCFFFF&}いい{\c&HCCFFFF&}{\c&HFFFFFF&}よ{\c&HFFFFFF&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HCCFFCC&}N{\c&HCCFFCC&}{\c&HFFFFCC&}お{\c&HFFFFCC&}{\c&HFFCCCC&}持ち帰り{\c&HFFCCCC&}{\c&HFFCCFF&}し{\c&HFFCCFF&}たい！
+Dialogue: 0,0:11:40.36,0:11:43.46,Default,,0,0,0,,{\c&HFFFFF0&}It's{\c&HFFFFF0&} {\c&HFFF5EE&}so{\c&HFFF5EE&} {\c&HFAEBD7&}cute{\c&HFAEBD7&} {\c&HFFFAFA&}!\{\c&HFFFAFA&} {\c&HCCFFFF&}NI{\c&HCCFFFF&} {\c&HFFFFFF&}want{\c&HFFFFFF&} {\c&HCCFFFF&}to{\c&HCCFFFF&} {\c&HCCFFCC&}take{\c&HCCFFCC&} {\c&HFFFFCC&}him{\c&HFFFFCC&} {\c&HFFCCCC&}home{\c&HFFCCCC&} {\c&HFFCCFF&}!{\c&HFFCCFF&}
+Dialogue: 0,0:11:43.93,0:11:46.30,Default-ja,,0,0,0,,{\c&HCCE5FF&}フフッ{\c&HCCE5FF&}{\c&HFFD8B1&}…{\c&HFFD8B1&}{\c&HCCE0FF&}あれ{\c&HCCE0FF&}{\c&HFFFFE0&}は{\c&HFFFFE0&}{\c&HFFF0F5&}ゴミ{\c&HFFF0F5&}だろう
+Dialogue: 0,0:11:45.00,0:11:46.43,Default,,0,0,0,,{\c&HCCE5FF&}That's{\c&HCCE5FF&} {\c&HFFD8B1&}trash{\c&HFFD8B1&} {\c&HCCE0FF&},{\c&HCCE0FF&} {\c&HFFFFE0&}right{\c&HFFFFE0&} {\c&HFFF0F5&}?{\c&HFFF0F5&}
+Dialogue: 0,0:11:46.47,0:11:49.14,Default-ja,,0,0,0,,{\c&HFFE4E1&}お{\c&HFFE4E1&}{\c&HFAFAD2&}持ち帰り{\c&HFAFAD2&}{\c&HFFFACD&}し{\c&HFFFACD&}{\c&HFFEFD5&}たきゃ{\c&HFFEFD5&}{\c&HFFFFF0&}\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}{\c&HFAEBD7&}し{\c&HFAEBD7&}{\c&HFFFAFA&}て{\c&HFFFAFA&}{\c&HCCFFFF&}も{\c&HCCFFFF&}{\c&HFFFFFF&}いい{\c&HFFFFFF&}{\c&HCCFFFF&}ん{\c&HCCFFFF&}{\c&HCCFFCC&}だ{\c&HCCFFCC&}ぜ
+Dialogue: 0,0:11:46.53,0:11:49.87,Default,,0,0,0,,{\c&HFFE4E1&}If{\c&HFFE4E1&} {\c&HFAFAD2&}you{\c&HFAFAD2&} {\c&HFFFACD&}want{\c&HFFFACD&} {\c&HFFEFD5&}to{\c&HFFEFD5&} {\c&HFFFFF0&}take{\c&HFFFFF0&} {\c&HFFF5EE&}it{\c&HFFF5EE&} {\c&HFAEBD7&},\{\c&HFAEBD7&} {\c&HFFFAFA&}NI'm{\c&HFFFAFA&} {\c&HCCFFFF&}sure{\c&HCCFFFF&} {\c&HFFFFFF&}you{\c&HFFFFFF&} {\c&HCCFFFF&}could{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:11:49.97,0:11:54.27,Default,,0,0,0,,{\c&HFFFFCC&}The{\c&HFFFFCC&} {\c&HFFCCCC&}Kenta{\c&HFFCCCC&} {\c&HFFCCFF&}doll{\c&HFFCCFF&} {\c&HCCE5FF&}is{\c&HCCE5FF&} {\c&HFFD8B1&}trapped{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}Nunder{\c&HFFFFE0&} {\c&HFFF0F5&}a{\c&HFFF0F5&} {\c&HFFE4E1&}pile{\c&HFFE4E1&} {\c&HFAFAD2&}of{\c&HFAFAD2&} {\c&HFFFACD&}junk{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:11:50.00,0:11:54.14,Default-ja,,0,0,0,,{\c&HFFFFCC&}ケンタ{\c&HFFFFCC&}{\c&HFFCCCC&}くん{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}{\c&HFFD8B1&}ゴミ{\c&HFFD8B1&}{\c&HCCE0FF&}の{\c&HCCE0FF&}{\c&HFFFFE0&}山{\c&HFFFFE0&}{\c&HFFF0F5&}の{\c&HFFF0F5&}{\c&HFFE4E1&}下敷き{\c&HFFE4E1&}{\c&HFAFAD2&}に{\c&HFAFAD2&}{\c&HFFFACD&}なっ{\c&HFFFACD&}{\c&HFFEFD5&}てる{\c&HFFEFD5&}の
+Dialogue: 0,0:11:54.34,0:11:56.54,Default-ja,,0,0,0,,{\c&HFFFFF0&}簡単{\c&HFFFFF0&}{\c&HFFF5EE&}に{\c&HFFF5EE&}{\c&HFAEBD7&}は{\c&HFAEBD7&}{\c&HFFFAFA&}掘り出せ{\c&HFFFAFA&}{\c&HCCFFFF&}ない{\c&HCCFFFF&}{\c&HFFFFFF&}よ{\c&HFFFFFF&}
+Dialogue: 0,0:11:54.38,0:11:56.84,Default,,0,0,0,,{\c&HFFFFF0&}I{\c&HFFFFF0&} {\c&HFFF5EE&}can't{\c&HFFF5EE&} {\c&HFAEBD7&}easily{\c&HFAEBD7&} {\c&HFFFAFA&}dig{\c&HFFFAFA&} {\c&HCCFFFF&}him{\c&HCCFFFF&} {\c&HFFFFFF&}out{\c&HFFFFFF&} .
+Dialogue: 0,0:11:56.94,0:11:59.31,Default,,0,0,0,,{\c&HCCFFFF&}I'll{\c&HCCFFFF&} {\c&HCCFFCC&}help{\c&HCCFFCC&} {\c&HFFFFCC&}you{\c&HFFFFCC&} {\c&HFFCCCC&}tomorrow{\c&HFFCCCC&} {\c&HFFCCFF&}.{\c&HFFCCFF&}
+Dialogue: 0,0:11:56.98,0:12:00.08,Default-ja,,0,0,0,,{\c&HCCFFFF&}あした{\c&HCCFFFF&}{\c&HCCFFCC&}俺{\c&HCCFFCC&}{\c&HFFFFCC&}も{\c&HFFFFCC&}{\c&HFFCCCC&}手伝っ{\c&HFFCCCC&}{\c&HFFCCFF&}て{\c&HFFCCFF&}やるよ\N（ﾚﾅ）えっ？
+Dialogue: 0,0:12:00.45,0:12:02.55,Default-ja,,0,0,0,,{\c&HCCE5FF&}弁当{\c&HCCE5FF&}{\c&HFFD8B1&}の{\c&HFFD8B1&}{\c&HCCE0FF&}恩返し{\c&HCCE0FF&}{\c&HFFFFE0&}って{\c&HFFFFE0&}{\c&HFFF0F5&}こと{\c&HFFF0F5&}{\c&HFFE4E1&}で{\c&HFFE4E1&}さ
+Dialogue: 0,0:12:00.51,0:12:02.57,Default,,0,0,0,,{\c&HCCE5FF&}In{\c&HCCE5FF&} {\c&HFFD8B1&}exchange{\c&HFFD8B1&} {\c&HCCE0FF&}for{\c&HCCE0FF&} {\c&HFFFFE0&}lunch{\c&HFFFFE0&} {\c&HFFF0F5&}today{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
+Dialogue: 0,0:12:02.92,0:12:05.05,Default-ja,,0,0,0,,{\c&HFAFAD2&}あ{\c&HFAFAD2&}{\c&HFFFACD&}…{\c&HFFFACD&}ありがとう
+Dialogue: 0,0:12:03.58,0:12:05.02,Default,,0,0,0,,{\c&HFAFAD2&}Thanks{\c&HFAFAD2&} {\c&HFFFACD&}!{\c&HFFFACD&}
+Dialogue: 0,0:12:05.12,0:12:07.49,Default,,0,0,0,,{\c&HFFEFD5&}Keiichi{\c&HFFEFD5&} {\c&HFFFFF0&}-{\c&HFFFFF0&} {\c&HFFF5EE&}kun{\c&HFFF5EE&} {\c&HFAEBD7&}will{\c&HFAEBD7&} {\c&HFFFAFA&}help{\c&HFFFAFA&} {\c&HCCFFFF&}...{\c&HCCFFFF&}
+Dialogue: 0,0:12:05.15,0:12:07.39,Default-ja,,0,0,0,,{\c&HFFEFD5&}圭一{\c&HFFEFD5&}{\c&HFFFFF0&}君{\c&HFFFFF0&}{\c&HFFF5EE&}が{\c&HFFF5EE&}{\c&HFAEBD7&}手伝っ{\c&HFAEBD7&}{\c&HFFFAFA&}て{\c&HFFFAFA&}{\c&HCCFFFF&}くれる{\c&HCCFFFF&}…
+Dialogue: 0,0:12:07.49,0:12:10.23,Default-ja,,0,0,0,,{\c&HFFFFFF&}ケンタ{\c&HFFFFFF&}{\c&HCCFFFF&}くん{\c&HCCFFFF&}{\c&HCCFFCC&}を{\c&HCCFFCC&}{\c&HFFFFCC&}お{\c&HFFFFCC&}{\c&HFFCCCC&}持ち帰り{\c&HFFCCCC&}{\c&HFFCCFF&}できる{\c&HFFCCFF&}{\c&HCCE5FF&}！{\c&HCCE5FF&}
+Dialogue: 0,0:12:07.59,0:12:11.32,Default,,0,0,0,,{\c&HFFFFFF&}I'll{\c&HFFFFFF&} {\c&HCCFFFF&}get{\c&HCCFFFF&} {\c&HCCFFCC&}to{\c&HCCFFCC&} {\c&HFFFFCC&}take{\c&HFFFFCC&} {\c&HFFCCCC&}\{\c&HFFCCCC&} {\c&HFFCCFF&}Nthe{\c&HFFCCFF&} {\c&HCCE5FF&}Kenta{\c&HCCE5FF&} doll home !
+Dialogue: 0,0:12:12.76,0:12:16.20,Default,,0,0,0,,{\c&HFFD8B1&}Hey{\c&HFFD8B1&} {\c&HCCE0FF&},{\c&HCCE0FF&} {\c&HFFFFE0&}Rena{\c&HFFFFE0&} {\c&HFFF0F5&},{\c&HFFF0F5&} {\c&HFFE4E1&}did{\c&HFFE4E1&} {\c&HFAFAD2&}something{\c&HFAFAD2&} {\c&HFFFACD&}\{\c&HFFFACD&} {\c&HFFEFD5&}Nhappen{\c&HFFEFD5&} {\c&HFFFFF0&}here{\c&HFFFFF0&} {\c&HFFF5EE&}in{\c&HFFF5EE&} {\c&HFAEBD7&}the{\c&HFAEBD7&} {\c&HFFFAFA&}past{\c&HFFFAFA&} {\c&HCCFFFF&}?{\c&HCCFFFF&}
+Dialogue: 0,0:12:12.89,0:12:16.23,Default-ja,,0,0,0,,{\c&HFFD8B1&}なあ{\c&HFFD8B1&}{\c&HCCE0FF&}レナ{\c&HCCE0FF&}{\c&HFFFFE0&}\{\c&HFFFFE0&}{\c&HFFF0F5&}N{\c&HFFF0F5&}{\c&HFFE4E1&}ここ{\c&HFFE4E1&}{\c&HFAFAD2&}で{\c&HFAFAD2&}{\c&HFFFACD&}昔{\c&HFFFACD&}{\c&HFFEFD5&}何{\c&HFFEFD5&}{\c&HFFFFF0&}か{\c&HFFFFF0&}{\c&HFFF5EE&}あっ{\c&HFFF5EE&}{\c&HFAEBD7&}た{\c&HFAEBD7&}{\c&HFFFAFA&}の{\c&HFFFAFA&}{\c&HCCFFFF&}か{\c&HCCFFFF&}？
+Dialogue: 0,0:12:16.36,0:12:19.63,Default-ja,,0,0,0,,{\c&HFFFFFF&}あっ{\c&HFFFFFF&}{\c&HCCFFFF&}…{\c&HCCFFFF&}{\c&HCCFFCC&}\{\c&HCCFFCC&}{\c&HFFFFCC&}N{\c&HFFFFCC&}{\c&HFFCCCC&}ダム{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}{\c&HCCE5FF&}工事{\c&HCCE5FF&}{\c&HFFD8B1&}を{\c&HFFD8B1&}やってたんだって
+Dialogue: 0,0:12:17.10,0:12:19.93,Default,,0,0,0,,{\c&HFFFFFF&}I{\c&HFFFFFF&} {\c&HCCFFFF&}heard{\c&HCCFFFF&} {\c&HCCFFCC&}they{\c&HCCFFCC&} {\c&HFFFFCC&}were{\c&HFFFFCC&} {\c&HFFCCCC&}building{\c&HFFCCCC&} {\c&HFFCCFF&}a{\c&HFFCCFF&} {\c&HCCE5FF&}dam{\c&HCCE5FF&} {\c&HFFD8B1&}.{\c&HFFD8B1&}
+Dialogue: 0,0:12:20.03,0:12:22.76,Default,,0,0,0,,{\c&HCCE0FF&}I{\c&HCCE0FF&} {\c&HFFFFE0&}don't{\c&HFFFFE0&} {\c&HFFF0F5&}know{\c&HFFF0F5&} {\c&HFFE4E1&}too{\c&HFFE4E1&} {\c&HFAFAD2&}much{\c&HFAFAD2&} about it .
+Dialogue: 0,0:12:20.07,0:12:22.24,Default-ja,,0,0,0,,{\c&HCCE0FF&}詳しく{\c&HCCE0FF&}{\c&HFFFFE0&}は{\c&HFFFFE0&}{\c&HFFF0F5&}知ら{\c&HFFF0F5&}{\c&HFFE4E1&}ない{\c&HFFE4E1&}{\c&HFAFAD2&}けど{\c&HFAFAD2&}
+Dialogue: 0,0:12:22.87,0:12:25.13,Default,,0,0,0,,{\c&HFFFACD&}They{\c&HFFFACD&} {\c&HFFEFD5&}were{\c&HFFEFD5&} {\c&HFFFFF0&}building{\c&HFFFFF0&} {\c&HFFF5EE&}a{\c&HFFF5EE&} dam ?
+Dialogue: 0,0:12:22.94,0:12:24.24,Default-ja,,0,0,0,,{\c&HFFFACD&}ダム{\c&HFFFACD&}{\c&HFFEFD5&}の{\c&HFFEFD5&}{\c&HFFFFF0&}工事{\c&HFFFFF0&}{\c&HFFF5EE&}？{\c&HFFF5EE&}
+Dialogue: 0,0:12:25.21,0:12:29.24,Default-ja,,0,0,0,,{\c&HFAEBD7&}例えば{\c&HFAEBD7&}{\c&HFFFAFA&}さ{\c&HFFFAFA&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}{\c&HCCFFFF&}その{\c&HCCFFFF&}{\c&HCCFFCC&}工事{\c&HCCFFCC&}{\c&HFFFFCC&}中{\c&HFFFFCC&}{\c&HFFCCCC&}に{\c&HFFCCCC&}{\c&HFFCCFF&}何{\c&HFFCCFF&}{\c&HCCE5FF&}か{\c&HCCE5FF&}{\c&HFFD8B1&}あっ{\c&HFFD8B1&}たとか
+Dialogue: 0,0:12:25.24,0:12:30.23,Default,,0,0,0,,{\c&HFAEBD7&}Did{\c&HFAEBD7&} {\c&HFFFAFA&}something{\c&HFFFAFA&} {\c&HCCFFFF&}happen{\c&HCCFFFF&} {\c&HFFFFFF&}during{\c&HFFFFFF&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HCCFFCC&}Nconstruction{\c&HCCFFCC&} {\c&HFFFFCC&},{\c&HFFFFCC&} {\c&HFFCCCC&}like{\c&HFFCCCC&} {\c&HFFCCFF&}an{\c&HFFCCFF&} {\c&HCCE5FF&}accident{\c&HCCE5FF&} {\c&HFFD8B1&}?{\c&HFFD8B1&}
+Dialogue: 0,0:12:29.44,0:12:30.31,Default-ja,,0,0,0,,{\c&HCCE0FF&}事故{\c&HCCE0FF&}{\c&HFFFFE0&}とか{\c&HFFFFE0&}{\c&HFFF0F5&}…{\c&HFFF0F5&}
+Dialogue: 0,0:12:30.34,0:12:31.83,Default,,0,0,0,,{\c&HCCE0FF&}I{\c&HCCE0FF&} {\c&HFFFFE0&}don't{\c&HFFFFE0&} {\c&HFFF0F5&}know{\c&HFFF0F5&} .
 Dialogue: 0,0:12:30.41,0:12:32.38,Default-ja,,0,0,0,,知らない\N（圭一）えっ？
-Dialogue: 0,0:12:33.45,0:12:36.28,Default-ja,,0,0,0,,レナ 去年まで よそに住んでたの
-Dialogue: 0,0:12:33.61,0:12:37.07,Default,,0,0,0,,I was living\Nsomewhere else till last year.
-Dialogue: 0,0:12:37.18,0:12:40.31,Default,,0,0,0,,You were a transfer student too?
-Dialogue: 0,0:12:37.22,0:12:39.89,Default-ja,,0,0,0,,レナも転校生だったのか
-Dialogue: 0,0:12:40.36,0:12:41.96,Default-ja,,0,0,0,,俺は てっきり…
-Dialogue: 0,0:12:40.42,0:12:41.98,Default,,0,0,0,,I assumed...
-Dialogue: 0,0:12:42.09,0:12:47.62,Default,,0,0,0,,So I don't know much about what\Nhappened before then, sorry.
-Dialogue: 0,0:12:42.09,0:12:46.29,Default-ja,,0,0,0,,だからね\Nそれ以前のことは よく知らないの
-Dialogue: 0,0:12:46.56,0:12:49.23,Default-ja,,0,0,0,,ごめんね\N（圭一）ああ そうか
-Dialogue: 0,0:12:47.73,0:12:49.16,Default,,0,0,0,,Oh, okay.
+Dialogue: 0,0:12:33.45,0:12:36.28,Default-ja,,0,0,0,,{\c&HFFE4E1&}レナ{\c&HFFE4E1&}{\c&HFAFAD2&}去年{\c&HFAFAD2&}{\c&HFFFACD&}まで{\c&HFFFACD&}{\c&HFFEFD5&}よそ{\c&HFFEFD5&}{\c&HFFFFF0&}に{\c&HFFFFF0&}{\c&HFFF5EE&}住ん{\c&HFFF5EE&}{\c&HFAEBD7&}で{\c&HFAEBD7&}{\c&HFFFAFA&}た{\c&HFFFAFA&}{\c&HCCFFFF&}の{\c&HCCFFFF&}
+Dialogue: 0,0:12:33.61,0:12:37.07,Default,,0,0,0,,{\c&HFFE4E1&}I{\c&HFFE4E1&} {\c&HFAFAD2&}was{\c&HFAFAD2&} {\c&HFFFACD&}living{\c&HFFFACD&} {\c&HFFEFD5&}\{\c&HFFEFD5&} {\c&HFFFFF0&}Nsomewhere{\c&HFFFFF0&} {\c&HFFF5EE&}else{\c&HFFF5EE&} {\c&HFAEBD7&}till{\c&HFAEBD7&} {\c&HFFFAFA&}last{\c&HFFFAFA&} {\c&HCCFFFF&}year{\c&HCCFFFF&} .
+Dialogue: 0,0:12:37.18,0:12:40.31,Default,,0,0,0,,{\c&HFFFFFF&}You{\c&HFFFFFF&} {\c&HCCFFFF&}were{\c&HCCFFFF&} {\c&HCCFFCC&}a{\c&HCCFFCC&} {\c&HFFFFCC&}transfer{\c&HFFFFCC&} {\c&HFFCCCC&}student{\c&HFFCCCC&} {\c&HFFCCFF&}too{\c&HFFCCFF&} {\c&HCCE5FF&}?{\c&HCCE5FF&}
+Dialogue: 0,0:12:37.22,0:12:39.89,Default-ja,,0,0,0,,{\c&HFFFFFF&}レナ{\c&HFFFFFF&}{\c&HCCFFFF&}も{\c&HCCFFFF&}{\c&HCCFFCC&}転校生{\c&HCCFFCC&}{\c&HFFFFCC&}だっ{\c&HFFFFCC&}{\c&HFFCCCC&}た{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}{\c&HCCE5FF&}か{\c&HCCE5FF&}
+Dialogue: 0,0:12:40.36,0:12:41.96,Default-ja,,0,0,0,,{\c&HFFD8B1&}俺{\c&HFFD8B1&}{\c&HCCE0FF&}は{\c&HCCE0FF&}{\c&HFFFFE0&}てっきり{\c&HFFFFE0&}…
+Dialogue: 0,0:12:40.42,0:12:41.98,Default,,0,0,0,,{\c&HFFD8B1&}I{\c&HFFD8B1&} {\c&HCCE0FF&}assumed{\c&HCCE0FF&} {\c&HFFFFE0&}...{\c&HFFFFE0&}
+Dialogue: 0,0:12:42.09,0:12:47.62,Default,,0,0,0,,{\c&HFFF0F5&}So{\c&HFFF0F5&} {\c&HFFE4E1&}I{\c&HFFE4E1&} {\c&HFAFAD2&}don't{\c&HFAFAD2&} {\c&HFFFACD&}know{\c&HFFFACD&} {\c&HFFEFD5&}much{\c&HFFEFD5&} {\c&HFFFFF0&}about{\c&HFFFFF0&} {\c&HFFF5EE&}what{\c&HFFF5EE&} {\c&HFAEBD7&}\{\c&HFAEBD7&} {\c&HFFFAFA&}Nhappened{\c&HFFFAFA&} {\c&HCCFFFF&}before{\c&HCCFFFF&} {\c&HFFFFFF&}then{\c&HFFFFFF&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HCCFFCC&}sorry{\c&HCCFFCC&} .
+Dialogue: 0,0:12:42.09,0:12:46.29,Default-ja,,0,0,0,,{\c&HFFF0F5&}だから{\c&HFFF0F5&}{\c&HFFE4E1&}ね{\c&HFFE4E1&}{\c&HFAFAD2&}\{\c&HFAFAD2&}{\c&HFFFACD&}N{\c&HFFFACD&}{\c&HFFEFD5&}それ{\c&HFFEFD5&}{\c&HFFFFF0&}以前{\c&HFFFFF0&}{\c&HFFF5EE&}の{\c&HFFF5EE&}{\c&HFAEBD7&}こと{\c&HFAEBD7&}{\c&HFFFAFA&}は{\c&HFFFAFA&}{\c&HCCFFFF&}よく{\c&HCCFFFF&}{\c&HFFFFFF&}知ら{\c&HFFFFFF&}{\c&HCCFFFF&}ない{\c&HCCFFFF&}{\c&HCCFFCC&}の{\c&HCCFFCC&}
+Dialogue: 0,0:12:46.56,0:12:49.23,Default-ja,,0,0,0,,{\c&HFFFFCC&}ごめん{\c&HFFFFCC&}{\c&HFFCCCC&}ね{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}（圭一）ああそうか
+Dialogue: 0,0:12:47.73,0:12:49.16,Default,,0,0,0,,{\c&HFFFFCC&}Oh{\c&HFFFFCC&} {\c&HFFCCCC&},{\c&HFFCCCC&} {\c&HFFCCFF&}okay{\c&HFFCCFF&} {\c&HCCE5FF&}.{\c&HCCE5FF&}
 Dialogue: 0,0:12:53.00,0:12:56.90,Default,,0,0,0,,When They Cry
 Dialogue: 0,0:12:58.31,0:13:01.90,Default,,0,0,0,,When They Cry
-Dialogue: 0,0:13:04.95,0:13:07.78,Default,,0,0,0,,- Bye!\N- See you later!
-Dialogue: 0,0:13:05.04,0:13:06.94,Default-ja,,0,0,0,,（女の子）さようなら\N（男の子）またね
-Dialogue: 0,0:13:08.75,0:13:09.81,Default,,0,0,0,,Let's see...
-Dialogue: 0,0:13:08.84,0:13:11.27,Default-ja,,0,0,0,,（魅音）\Nさてと 今日は会則にのっとり―
-Dialogue: 0,0:13:09.92,0:13:13.44,Default,,0,0,0,,I would like to act\Naccording to our rules...
-Dialogue: 0,0:13:11.38,0:13:13.64,Default-ja,,0,0,0,,部員の諸君に是非を問いたい
-Dialogue: 0,0:13:14.05,0:13:20.46,Default,,0,0,0,,...and debate the merits of inviting\NKeiichi Maebara to our club!
-Dialogue: 0,0:13:14.08,0:13:17.01,Default-ja,,0,0,0,,彼 前原(まえばら)圭一君を\N新たな部員として―
-Dialogue: 0,0:13:17.11,0:13:20.65,Default-ja,,0,0,0,,我らの部活動に加えたいのだが\Nいかがだろうか？
-Dialogue: 0,0:13:20.86,0:13:22.45,Default,,0,0,0,,No objections!
-Dialogue: 0,0:13:20.95,0:13:22.65,Default-ja,,0,0,0,,レナは異議な～し！
-Dialogue: 0,0:13:22.63,0:13:24.10,Default,,0,0,0,,Ha ha ha
-Dialogue: 0,0:13:24.53,0:13:28.14,Default,,0,0,0,,Can the peasant\Nkeep up with me?
-Dialogue: 0,0:13:24.69,0:13:28.19,Default-ja,,0,0,0,,貧民風情が\N私の相手を務められるかしら？
-Dialogue: 0,0:13:28.14,0:13:30.97,Default,,0,0,0,,Satoko and I agree too.
-Dialogue: 0,0:13:28.29,0:13:31.06,Default-ja,,0,0,0,,ボクも沙都子も賛成しますですよ
-Dialogue: 0,0:13:31.21,0:13:34.20,Default,,0,0,0,,It's unanimous!\NCongrats, Keiichi Maebara!
-Dialogue: 0,0:13:31.23,0:13:36.40,Default-ja,,0,0,0,,全会一致！ おめでとう 前原圭一君\N君に 我が部への入部を許可する！
+Dialogue: 0,0:13:04.95,0:13:07.78,Default,,0,0,0,,{\c&HFFD8B1&}-{\c&HFFD8B1&} {\c&HCCE0FF&}Bye{\c&HCCE0FF&} {\c&HFFFFE0&}!\{\c&HFFFFE0&} {\c&HFFF0F5&}N{\c&HFFF0F5&} {\c&HFFE4E1&}-{\c&HFFE4E1&} {\c&HFAFAD2&}See{\c&HFAFAD2&} {\c&HFFFACD&}you{\c&HFFFACD&} {\c&HFFEFD5&}later{\c&HFFEFD5&} {\c&HFFFFF0&}!{\c&HFFFFF0&}
+Dialogue: 0,0:13:05.04,0:13:06.94,Default-ja,,0,0,0,,{\c&HFFD8B1&}（{\c&HFFD8B1&}{\c&HCCE0FF&}女の子{\c&HCCE0FF&}{\c&HFFFFE0&}）{\c&HFFFFE0&}{\c&HFFF0F5&}さようなら{\c&HFFF0F5&}{\c&HFFE4E1&}\{\c&HFFE4E1&}{\c&HFAFAD2&}N{\c&HFAFAD2&}{\c&HFFFACD&}（{\c&HFFFACD&}{\c&HFFEFD5&}男の子{\c&HFFEFD5&}{\c&HFFFFF0&}）{\c&HFFFFF0&}またね
+Dialogue: 0,0:13:08.75,0:13:09.81,Default,,0,0,0,,{\c&HFFF5EE&}Let's{\c&HFFF5EE&} {\c&HFAEBD7&}see{\c&HFAEBD7&} {\c&HFFFAFA&}...{\c&HFFFAFA&}
+Dialogue: 0,0:13:08.84,0:13:11.27,Default-ja,,0,0,0,,{\c&HFFF5EE&}（{\c&HFFF5EE&}{\c&HFAEBD7&}魅{\c&HFAEBD7&}{\c&HFFFAFA&}音{\c&HFFFAFA&}）\Nさてと今日は会則にのっとり―
+Dialogue: 0,0:13:09.92,0:13:13.44,Default,,0,0,0,,{\c&HCCFFFF&}I{\c&HCCFFFF&} {\c&HFFFFFF&}would{\c&HFFFFFF&} {\c&HCCFFFF&}like{\c&HCCFFFF&} {\c&HCCFFCC&}to{\c&HCCFFCC&} {\c&HFFFFCC&}act{\c&HFFFFCC&} {\c&HFFCCCC&}\{\c&HFFCCCC&} {\c&HFFCCFF&}Naccording{\c&HFFCCFF&} {\c&HCCE5FF&}to{\c&HCCE5FF&} our rules ...
+Dialogue: 0,0:13:11.38,0:13:13.64,Default-ja,,0,0,0,,{\c&HCCFFFF&}部員{\c&HCCFFFF&}{\c&HFFFFFF&}の{\c&HFFFFFF&}{\c&HCCFFFF&}諸君{\c&HCCFFFF&}{\c&HCCFFCC&}に{\c&HCCFFCC&}{\c&HFFFFCC&}是非{\c&HFFFFCC&}{\c&HFFCCCC&}を{\c&HFFCCCC&}{\c&HFFCCFF&}問い{\c&HFFCCFF&}{\c&HCCE5FF&}たい{\c&HCCE5FF&}
+Dialogue: 0,0:13:14.05,0:13:20.46,Default,,0,0,0,,{\c&HFFD8B1&}...{\c&HFFD8B1&} {\c&HCCE0FF&}and{\c&HCCE0FF&} {\c&HFFFFE0&}debate{\c&HFFFFE0&} {\c&HFFF0F5&}the{\c&HFFF0F5&} {\c&HFFE4E1&}merits{\c&HFFE4E1&} {\c&HFAFAD2&}of{\c&HFAFAD2&} {\c&HFFFACD&}inviting{\c&HFFFACD&} {\c&HFFEFD5&}\{\c&HFFEFD5&} {\c&HFFFFF0&}NKeiichi{\c&HFFFFF0&} {\c&HFFF5EE&}Maebara{\c&HFFF5EE&} {\c&HFAEBD7&}to{\c&HFAEBD7&} {\c&HFFFAFA&}our{\c&HFFFAFA&} {\c&HCCFFFF&}club{\c&HCCFFFF&} {\c&HFFFFFF&}!{\c&HFFFFFF&}
+Dialogue: 0,0:13:14.08,0:13:17.01,Default-ja,,0,0,0,,{\c&HFFD8B1&}彼{\c&HFFD8B1&}{\c&HCCE0FF&}前原{\c&HCCE0FF&}{\c&HFFFFE0&}({\c&HFFFFE0&}{\c&HFFF0F5&}まえ{\c&HFFF0F5&}{\c&HFFE4E1&}ばら{\c&HFFE4E1&}{\c&HFAFAD2&}){\c&HFAFAD2&}{\c&HFFFACD&}圭一{\c&HFFFACD&}{\c&HFFEFD5&}君{\c&HFFEFD5&}{\c&HFFFFF0&}を{\c&HFFFFF0&}{\c&HFFF5EE&}\{\c&HFFF5EE&}{\c&HFAEBD7&}N{\c&HFAEBD7&}{\c&HFFFAFA&}新た{\c&HFFFAFA&}{\c&HCCFFFF&}な{\c&HCCFFFF&}{\c&HFFFFFF&}部員{\c&HFFFFFF&}として―
+Dialogue: 0,0:13:17.11,0:13:20.65,Default-ja,,0,0,0,,{\c&HCCFFFF&}我ら{\c&HCCFFFF&}{\c&HCCFFCC&}の{\c&HCCFFCC&}{\c&HFFFFCC&}部{\c&HFFFFCC&}活動に加えたいのだが\Nいかがだろうか？
+Dialogue: 0,0:13:20.86,0:13:22.45,Default,,0,0,0,,{\c&HCCFFFF&}No{\c&HCCFFFF&} {\c&HCCFFCC&}objections{\c&HCCFFCC&} {\c&HFFFFCC&}!{\c&HFFFFCC&}
+Dialogue: 0,0:13:20.95,0:13:22.65,Default-ja,,0,0,0,,{\c&HFFCCCC&}レナ{\c&HFFCCCC&}{\c&HFFCCFF&}は{\c&HFFCCFF&}{\c&HCCE5FF&}異議{\c&HCCE5FF&}な～し！
+Dialogue: 0,0:13:22.63,0:13:24.10,Default,,0,0,0,,{\c&HFFCCCC&}Ha{\c&HFFCCCC&} {\c&HFFCCFF&}ha{\c&HFFCCFF&} {\c&HCCE5FF&}ha{\c&HCCE5FF&}
+Dialogue: 0,0:13:24.53,0:13:28.14,Default,,0,0,0,,{\c&HFFD8B1&}Can{\c&HFFD8B1&} {\c&HCCE0FF&}the{\c&HCCE0FF&} {\c&HFFFFE0&}peasant{\c&HFFFFE0&} {\c&HFFF0F5&}\{\c&HFFF0F5&} {\c&HFFE4E1&}Nkeep{\c&HFFE4E1&} {\c&HFAFAD2&}up{\c&HFAFAD2&} {\c&HFFFACD&}with{\c&HFFFACD&} {\c&HFFEFD5&}me{\c&HFFEFD5&} {\c&HFFFFF0&}?{\c&HFFFFF0&}
+Dialogue: 0,0:13:24.69,0:13:28.19,Default-ja,,0,0,0,,{\c&HFFD8B1&}貧民{\c&HFFD8B1&}{\c&HCCE0FF&}風情{\c&HCCE0FF&}{\c&HFFFFE0&}が{\c&HFFFFE0&}{\c&HFFF0F5&}\{\c&HFFF0F5&}{\c&HFFE4E1&}N{\c&HFFE4E1&}{\c&HFAFAD2&}私{\c&HFAFAD2&}{\c&HFFFACD&}の{\c&HFFFACD&}{\c&HFFEFD5&}相手{\c&HFFEFD5&}{\c&HFFFFF0&}を{\c&HFFFFF0&}務められるかしら？
+Dialogue: 0,0:13:28.14,0:13:30.97,Default,,0,0,0,,{\c&HFFF5EE&}Satoko{\c&HFFF5EE&} {\c&HFAEBD7&}and{\c&HFAEBD7&} {\c&HFFFAFA&}I{\c&HFFFAFA&} {\c&HCCFFFF&}agree{\c&HCCFFFF&} {\c&HFFFFFF&}too{\c&HFFFFFF&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:13:28.29,0:13:31.06,Default-ja,,0,0,0,,{\c&HFFF5EE&}ボク{\c&HFFF5EE&}{\c&HFAEBD7&}も{\c&HFAEBD7&}{\c&HFFFAFA&}沙都子{\c&HFFFAFA&}{\c&HCCFFFF&}も{\c&HCCFFFF&}{\c&HFFFFFF&}賛成{\c&HFFFFFF&}{\c&HCCFFFF&}し{\c&HCCFFFF&}ますですよ
+Dialogue: 0,0:13:31.21,0:13:34.20,Default,,0,0,0,,{\c&HCCFFCC&}It's{\c&HCCFFCC&} {\c&HFFFFCC&}unanimous{\c&HFFFFCC&} {\c&HFFCCCC&}!\{\c&HFFCCCC&} {\c&HFFCCFF&}NCongrats{\c&HFFCCFF&} {\c&HCCE5FF&},{\c&HCCE5FF&} {\c&HFFD8B1&}Keiichi{\c&HFFD8B1&} {\c&HCCE0FF&}Maebara{\c&HCCE0FF&} {\c&HFFFFE0&}!{\c&HFFFFE0&}
+Dialogue: 0,0:13:31.23,0:13:36.40,Default-ja,,0,0,0,,{\c&HCCFFCC&}全会{\c&HCCFFCC&}{\c&HFFFFCC&}一致{\c&HFFFFCC&}{\c&HFFCCCC&}！{\c&HFFCCCC&}{\c&HFFCCFF&}おめでとう{\c&HFFCCFF&}{\c&HCCE5FF&}前原{\c&HCCE5FF&}{\c&HFFD8B1&}圭一{\c&HFFD8B1&}{\c&HCCE0FF&}君{\c&HCCE0FF&}{\c&HFFFFE0&}\{\c&HFFFFE0&}N君に我が部への入部を許可する！
 Dialogue: 0,0:13:34.31,0:13:36.44,Default,,0,0,0,,I'll allow you to join!
-Dialogue: 0,0:13:36.54,0:13:39.64,Default,,0,0,0,,Hey, explain this!\NWhat's this club?
-Dialogue: 0,0:13:36.70,0:13:39.74,Default-ja,,0,0,0,,こら！ 順を追って説明しろ\N何の部活だ？
-Dialogue: 0,0:13:39.75,0:13:42.24,Default,,0,0,0,,Besides, I never said I'd join!
-Dialogue: 0,0:13:39.84,0:13:42.17,Default-ja,,0,0,0,,大体が 俺は\Nまだ“入る”とは言ってないぞ！
-Dialogue: 0,0:13:43.27,0:13:46.74,Default-ja,,0,0,0,,え～ 我が部はだな\N複雑化する社会に対応するため―
-Dialogue: 0,0:13:43.28,0:13:46.65,Default,,0,0,0,,Our club tries to counter\Nthis complicated society...
-Dialogue: 0,0:13:46.75,0:13:52.09,Default,,0,0,0,,...and in prosperity or adversity,\Nour activities are decided by...
-Dialogue: 0,0:13:46.84,0:13:49.28,Default-ja,,0,0,0,,活動ごとに提案される\Nさまざまな条件下―
+Dialogue: 0,0:13:36.54,0:13:39.64,Default,,0,0,0,,{\c&HFFF0F5&}Hey{\c&HFFF0F5&} {\c&HFFE4E1&},{\c&HFFE4E1&} {\c&HFAFAD2&}explain{\c&HFAFAD2&} {\c&HFFFACD&}this{\c&HFFFACD&} {\c&HFFEFD5&}!\{\c&HFFEFD5&} {\c&HFFFFF0&}NWhat's{\c&HFFFFF0&} {\c&HFFF5EE&}this{\c&HFFF5EE&} {\c&HFAEBD7&}club{\c&HFAEBD7&} {\c&HFFFAFA&}?{\c&HFFFAFA&}
+Dialogue: 0,0:13:36.70,0:13:39.74,Default-ja,,0,0,0,,{\c&HFFF0F5&}こら{\c&HFFF0F5&}{\c&HFFE4E1&}！{\c&HFFE4E1&}{\c&HFAFAD2&}順{\c&HFAFAD2&}{\c&HFFFACD&}を{\c&HFFFACD&}{\c&HFFEFD5&}追って{\c&HFFEFD5&}{\c&HFFFFF0&}説明{\c&HFFFFF0&}{\c&HFFF5EE&}しろ{\c&HFFF5EE&}{\c&HFAEBD7&}\{\c&HFAEBD7&}{\c&HFFFAFA&}N{\c&HFFFAFA&}何の部活だ？
+Dialogue: 0,0:13:39.75,0:13:42.24,Default,,0,0,0,,{\c&HCCFFFF&}Besides{\c&HCCFFFF&} {\c&HFFFFFF&},{\c&HFFFFFF&} {\c&HCCFFFF&}I{\c&HCCFFFF&} {\c&HCCFFCC&}never{\c&HCCFFCC&} {\c&HFFFFCC&}said{\c&HFFFFCC&} {\c&HFFCCCC&}I'd{\c&HFFCCCC&} {\c&HFFCCFF&}join{\c&HFFCCFF&} {\c&HCCE5FF&}!{\c&HCCE5FF&}
+Dialogue: 0,0:13:39.84,0:13:42.17,Default-ja,,0,0,0,,{\c&HCCFFFF&}大体{\c&HCCFFFF&}{\c&HFFFFFF&}が{\c&HFFFFFF&}{\c&HCCFFFF&}俺{\c&HCCFFFF&}{\c&HCCFFCC&}は{\c&HCCFFCC&}{\c&HFFFFCC&}\{\c&HFFFFCC&}{\c&HFFCCCC&}N{\c&HFFCCCC&}{\c&HFFCCFF&}まだ{\c&HFFCCFF&}{\c&HCCE5FF&}“{\c&HCCE5FF&}入る”とは言ってないぞ！
+Dialogue: 0,0:13:43.27,0:13:46.74,Default-ja,,0,0,0,,{\c&HFFD8B1&}え{\c&HFFD8B1&}{\c&HCCE0FF&}～{\c&HCCE0FF&}{\c&HFFFFE0&}我が{\c&HFFFFE0&}{\c&HFFF0F5&}部{\c&HFFF0F5&}{\c&HFFE4E1&}は{\c&HFFE4E1&}{\c&HFAFAD2&}だ{\c&HFAFAD2&}{\c&HFFFACD&}な{\c&HFFFACD&}{\c&HFFEFD5&}\{\c&HFFEFD5&}{\c&HFFFFF0&}N{\c&HFFFFF0&}{\c&HFFF5EE&}複雑{\c&HFFF5EE&}化する社会に対応するため―
+Dialogue: 0,0:13:43.28,0:13:46.65,Default,,0,0,0,,{\c&HFFD8B1&}Our{\c&HFFD8B1&} {\c&HCCE0FF&}club{\c&HCCE0FF&} {\c&HFFFFE0&}tries{\c&HFFFFE0&} {\c&HFFF0F5&}to{\c&HFFF0F5&} {\c&HFFE4E1&}counter{\c&HFFE4E1&} {\c&HFAFAD2&}\{\c&HFAFAD2&} {\c&HFFFACD&}Nthis{\c&HFFFACD&} {\c&HFFEFD5&}complicated{\c&HFFEFD5&} {\c&HFFFFF0&}society{\c&HFFFFF0&} {\c&HFFF5EE&}...{\c&HFFF5EE&}
+Dialogue: 0,0:13:46.75,0:13:52.09,Default,,0,0,0,,{\c&HFAEBD7&}...{\c&HFAEBD7&} {\c&HFFFAFA&}and{\c&HFFFAFA&} {\c&HCCFFFF&}in{\c&HCCFFFF&} {\c&HFFFFFF&}prosperity{\c&HFFFFFF&} {\c&HCCFFFF&}or{\c&HCCFFFF&} {\c&HCCFFCC&}adversity{\c&HCCFFCC&} {\c&HFFFFCC&},\{\c&HFFFFCC&} {\c&HFFCCCC&}Nour{\c&HFFCCCC&} {\c&HFFCCFF&}activities{\c&HFFCCFF&} {\c&HCCE5FF&}are{\c&HCCE5FF&} {\c&HFFD8B1&}decided{\c&HFFD8B1&} {\c&HCCE0FF&}by{\c&HCCE0FF&} ...
+Dialogue: 0,0:13:46.84,0:13:49.28,Default-ja,,0,0,0,,{\c&HFAEBD7&}活動{\c&HFAEBD7&}{\c&HFFFAFA&}ごと{\c&HFFFAFA&}{\c&HCCFFFF&}に{\c&HCCFFFF&}{\c&HFFFFFF&}提案{\c&HFFFFFF&}{\c&HCCFFFF&}さ{\c&HCCFFFF&}{\c&HCCFFCC&}れる{\c&HCCFFCC&}{\c&HFFFFCC&}\{\c&HFFFFCC&}{\c&HFFCCCC&}N{\c&HFFCCCC&}{\c&HFFCCFF&}さまざま{\c&HFFCCFF&}{\c&HCCE5FF&}な{\c&HCCE5FF&}{\c&HFFD8B1&}条件下{\c&HFFD8B1&}{\c&HCCE0FF&}―{\c&HCCE0FF&}
 Dialogue: 0,0:13:49.38,0:13:51.92,Default-ja,,0,0,0,,時には順境 あるいは逆境から\Nいかにして…
-Dialogue: 0,0:13:52.18,0:13:55.32,Default-ja,,0,0,0,,つまり みんなで\Nゲームして遊ぶ部活なのです
-Dialogue: 0,0:13:52.19,0:13:55.63,Default,,0,0,0,,Basically, we play\Ngames in our club.
-Dialogue: 0,0:13:55.73,0:13:57.22,Default,,0,0,0,,I get it.
-Dialogue: 0,0:13:55.82,0:13:58.89,Default-ja,,0,0,0,,ようやく分かった\N（魅音）先に断っとくけど…
-Dialogue: 0,0:13:57.33,0:14:01.56,Default,,0,0,0,,I'll make it clear first.\NWe don't play games like house.
-Dialogue: 0,0:13:58.99,0:14:01.69,Default-ja,,0,0,0,,ままごと遊びみたいな\Nレベルじゃないからね
-Dialogue: 0,0:14:01.67,0:14:03.69,Default,,0,0,0,,You'd better do your best.
-Dialogue: 0,0:14:01.79,0:14:03.86,Default-ja,,0,0,0,,本気で かかったほうがいいよ
-Dialogue: 0,0:14:03.80,0:14:07.50,Default,,0,0,0,,I-Isn't having fun enough?\NDon't threaten me...
-Dialogue: 0,0:14:03.96,0:14:06.26,Default-ja,,0,0,0,,た… 楽しくやればいいじゃねえか
-Dialogue: 0,0:14:06.36,0:14:09.13,Default-ja,,0,0,0,,そう すごむなよ\N（魅音）甘い！
-Dialogue: 0,0:14:07.61,0:14:09.13,Default,,0,0,0,,Weak!
-Dialogue: 0,0:14:09.23,0:14:11.97,Default-ja,,0,0,0,,会則 第１条 “狙うのは１位のみ”
-Dialogue: 0,0:14:09.24,0:14:11.91,Default,,0,0,0,,Article 1: Strive only for first!
-Dialogue: 0,0:14:12.01,0:14:14.78,Default,,0,0,0,,I won't allow that\Nstance in a game!
-Dialogue: 0,0:14:12.07,0:14:14.94,Default-ja,,0,0,0,,“遊びだから”なんていう\Nいいかげんなプレーは許さない！
-Dialogue: 0,0:14:15.02,0:14:20.35,Default,,0,0,0,,Article 2: To do that, putting forth\Nall possible effort is required.
-Dialogue: 0,0:14:15.07,0:14:18.71,Default-ja,,0,0,0,,会則 第２条 “そのためには\Nあらゆる努力をすること”が―
-Dialogue: 0,0:14:18.81,0:14:21.91,Default-ja,,0,0,0,,義務づけられておりますのよ\N（圭一）分かった 分かった
-Dialogue: 0,0:14:20.45,0:14:21.79,Default,,0,0,0,,I get it.
-Dialogue: 0,0:14:22.26,0:14:26.75,Default,,0,0,0,,Complex games will put\Nhim at a disadvantage...
-Dialogue: 0,0:14:22.31,0:14:26.75,Default-ja,,0,0,0,,じゃ 難しいゲームは\N圭ちゃんに不利になるから…
-Dialogue: 0,0:14:26.86,0:14:30.59,Default,,0,0,0,,...so let's play a game\Neverybody understands.
-Dialogue: 0,0:14:26.95,0:14:29.99,Default-ja,,0,0,0,,今日は\N誰にでも分かるゲームにしよう
-Dialogue: 0,0:14:30.70,0:14:33.72,Default,,0,0,0,,How about ordinary old maid?
-Dialogue: 0,0:14:30.85,0:14:33.49,Default-ja,,0,0,0,,スタンダードに\Nトランプのジジ抜きは どう？
-Dialogue: 0,0:14:33.79,0:14:34.83,Default-ja,,0,0,0,,（圭一）余裕だぜ！
-Dialogue: 0,0:14:33.83,0:14:35.46,Default,,0,0,0,,Piece of cake.
-Dialogue: 0,0:14:36.17,0:14:40.27,Default,,0,0,0,,For a punishment game, first\Nplace can order last place around.
-Dialogue: 0,0:14:36.19,0:14:39.90,Default-ja,,0,0,0,,（魅音）\N罰ゲームは １位がビリに１コ命令
-Dialogue: 0,0:14:40.36,0:14:41.43,Default-ja,,0,0,0,,この辺で どうかな？
-Dialogue: 0,0:14:40.37,0:14:41.40,Default,,0,0,0,,How's that?
-Dialogue: 0,0:14:41.81,0:14:43.50,Default,,0,0,0,,Bring it on.
-Dialogue: 0,0:14:41.90,0:14:43.50,Default-ja,,0,0,0,,上等でございますわ
-Dialogue: 0,0:14:44.01,0:14:46.64,Default,,0,0,0,,Okay, let's shuffle the cards.
-Dialogue: 0,0:14:44.07,0:14:46.77,Default-ja,,0,0,0,,（魅音）じゃ カードを切って…
-Dialogue: 0,0:14:48.34,0:14:49.51,Default-ja,,0,0,0,,（ﾚﾅ）１枚 抜くね
-Dialogue: 0,0:14:48.35,0:14:50.32,Default,,0,0,0,,I'll take this one.
-Dialogue: 0,0:14:50.75,0:14:53.52,Default,,0,0,0,,These cards are pretty worn.
-Dialogue: 0,0:14:50.87,0:14:55.01,Default-ja,,0,0,0,,このトランプ 結構 傷物だな\Nまさか みんなには―
-Dialogue: 0,0:14:53.62,0:14:58.02,Default,,0,0,0,,Don't tell me you all know which\Ncard is which from the scratches.
-Dialogue: 0,0:14:55.11,0:14:58.12,Default-ja,,0,0,0,,その傷で そこに伏せたカードが\N分かってるとか？
-Dialogue: 0,0:14:59.05,0:15:02.02,Default-ja,,0,0,0,,（ﾚﾅたち）ヘヘヘヘッ…\N（圭一）ちょ… ちょっと待て！
-Dialogue: 0,0:14:59.96,0:15:01.99,Default,,0,0,0,,H-Hold on!
-Dialogue: 0,0:15:02.10,0:15:03.43,Default,,0,0,0,,That's not fair!
-Dialogue: 0,0:15:02.12,0:15:03.45,Default-ja,,0,0,0,,そんなん ありかよ！
-Dialogue: 0,0:15:04.06,0:15:08.59,Default,,0,0,0,,Article 2: Putting forth all\Npossible effort is required.
-Dialogue: 0,0:15:04.12,0:15:08.49,Default-ja,,0,0,0,,会則 第２条 “勝つためには\Nあらゆる努力をすること”ですわ
-Dialogue: 0,0:15:08.70,0:15:13.54,Default,,0,0,0,,Some cards are really distinct,\Nso you'll notice them fast.
-Dialogue: 0,0:15:08.83,0:15:13.50,Default-ja,,0,0,0,,いくつかのカードは特徴的だから\N圭一君も すぐに覚えられるよ
-Dialogue: 0,0:15:13.64,0:15:17.94,Default,,0,0,0,,B-Bring it on! Don't think\Nthat this'll be a handicap!
-Dialogue: 0,0:15:13.80,0:15:18.07,Default-ja,,0,0,0,,じょ… 上等だぜ\Nこの程度でハンデになると思うなよ
-Dialogue: 0,0:15:25.28,0:15:29.55,Default-ja,,0,0,0,,ハハハッ！\N圭ちゃんの手札を右から言うよ
-Dialogue: 0,0:15:27.05,0:15:29.89,Default,,0,0,0,,I'll read your cards\Nfrom right to left.
-Dialogue: 0,0:15:29.99,0:15:32.55,Default,,0,0,0,,Three, four, nine, jack, queen.
-Dialogue: 0,0:15:30.05,0:15:32.55,Default-ja,,0,0,0,,（魅音）\N３ ４ ９ ジャック クイーン
-Dialogue: 0,0:15:32.88,0:15:33.55,Default-ja,,0,0,0,,グワーッ！
-Dialogue: 0,0:15:33.89,0:15:37.02,Default,,0,0,0,,By the way, the odd card\Nis the jack of diamonds.
+Dialogue: 0,0:13:52.18,0:13:55.32,Default-ja,,0,0,0,,{\c&HFFFFE0&}つまり{\c&HFFFFE0&}{\c&HFFF0F5&}みんな{\c&HFFF0F5&}{\c&HFFE4E1&}で{\c&HFFE4E1&}{\c&HFAFAD2&}\{\c&HFAFAD2&}{\c&HFFFACD&}N{\c&HFFFACD&}{\c&HFFEFD5&}ゲーム{\c&HFFEFD5&}{\c&HFFFFF0&}し{\c&HFFFFF0&}{\c&HFFF5EE&}て{\c&HFFF5EE&}{\c&HFAEBD7&}遊ぶ{\c&HFAEBD7&}{\c&HFFFAFA&}部活{\c&HFFFAFA&}なのです
+Dialogue: 0,0:13:52.19,0:13:55.63,Default,,0,0,0,,{\c&HFFFFE0&}Basically{\c&HFFFFE0&} {\c&HFFF0F5&},{\c&HFFF0F5&} {\c&HFFE4E1&}we{\c&HFFE4E1&} {\c&HFAFAD2&}play{\c&HFAFAD2&} {\c&HFFFACD&}\{\c&HFFFACD&} {\c&HFFEFD5&}Ngames{\c&HFFEFD5&} {\c&HFFFFF0&}in{\c&HFFFFF0&} {\c&HFFF5EE&}our{\c&HFFF5EE&} {\c&HFAEBD7&}club{\c&HFAEBD7&} {\c&HFFFAFA&}.{\c&HFFFAFA&}
+Dialogue: 0,0:13:55.73,0:13:57.22,Default,,0,0,0,,{\c&HCCFFFF&}I{\c&HCCFFFF&} {\c&HFFFFFF&}get{\c&HFFFFFF&} {\c&HCCFFFF&}it{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:13:55.82,0:13:58.89,Default-ja,,0,0,0,,{\c&HCCFFFF&}ようやく{\c&HCCFFFF&}{\c&HFFFFFF&}分かっ{\c&HFFFFFF&}{\c&HCCFFFF&}た{\c&HCCFFFF&}{\c&HCCFFCC&}\{\c&HCCFFCC&}N（魅音）先に断っとくけど…
+Dialogue: 0,0:13:57.33,0:14:01.56,Default,,0,0,0,,{\c&HFFFFCC&}I'll{\c&HFFFFCC&} {\c&HFFCCCC&}make{\c&HFFCCCC&} {\c&HFFCCFF&}it{\c&HFFCCFF&} {\c&HCCE5FF&}clear{\c&HCCE5FF&} {\c&HFFD8B1&}first{\c&HFFD8B1&} {\c&HCCE0FF&}.\{\c&HCCE0FF&} {\c&HFFFFE0&}NWe{\c&HFFFFE0&} {\c&HFFF0F5&}don't{\c&HFFF0F5&} {\c&HFFE4E1&}play{\c&HFFE4E1&} {\c&HFAFAD2&}games{\c&HFAFAD2&} {\c&HFFFACD&}like{\c&HFFFACD&} house .
+Dialogue: 0,0:13:58.99,0:14:01.69,Default-ja,,0,0,0,,{\c&HFFFFCC&}ままごと{\c&HFFFFCC&}{\c&HFFCCCC&}遊び{\c&HFFCCCC&}{\c&HFFCCFF&}みたい{\c&HFFCCFF&}{\c&HCCE5FF&}な{\c&HCCE5FF&}{\c&HFFD8B1&}\{\c&HFFD8B1&}{\c&HCCE0FF&}N{\c&HCCE0FF&}{\c&HFFFFE0&}レベル{\c&HFFFFE0&}{\c&HFFF0F5&}じゃ{\c&HFFF0F5&}{\c&HFFE4E1&}ない{\c&HFFE4E1&}{\c&HFAFAD2&}から{\c&HFAFAD2&}{\c&HFFFACD&}ね{\c&HFFFACD&}
+Dialogue: 0,0:14:01.67,0:14:03.69,Default,,0,0,0,,{\c&HFFEFD5&}You'd{\c&HFFEFD5&} {\c&HFFFFF0&}better{\c&HFFFFF0&} {\c&HFFF5EE&}do{\c&HFFF5EE&} {\c&HFAEBD7&}your{\c&HFAEBD7&} {\c&HFFFAFA&}best{\c&HFFFAFA&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:14:01.79,0:14:03.86,Default-ja,,0,0,0,,{\c&HFFEFD5&}本気{\c&HFFEFD5&}{\c&HFFFFF0&}で{\c&HFFFFF0&}{\c&HFFF5EE&}かかっ{\c&HFFF5EE&}{\c&HFAEBD7&}た{\c&HFAEBD7&}{\c&HFFFAFA&}ほう{\c&HFFFAFA&}{\c&HCCFFFF&}が{\c&HCCFFFF&}いいよ
+Dialogue: 0,0:14:03.80,0:14:07.50,Default,,0,0,0,,{\c&HFFFFFF&}I{\c&HFFFFFF&} {\c&HCCFFFF&}-{\c&HCCFFFF&} {\c&HCCFFCC&}Isn't{\c&HCCFFCC&} {\c&HFFFFCC&}having{\c&HFFFFCC&} {\c&HFFCCCC&}fun{\c&HFFCCCC&} {\c&HFFCCFF&}enough{\c&HFFCCFF&} {\c&HCCE5FF&}?\{\c&HCCE5FF&} {\c&HFFD8B1&}NDon't{\c&HFFD8B1&} {\c&HCCE0FF&}threaten{\c&HCCE0FF&} me ...
+Dialogue: 0,0:14:03.96,0:14:06.26,Default-ja,,0,0,0,,{\c&HFFFFFF&}た{\c&HFFFFFF&}{\c&HCCFFFF&}…{\c&HCCFFFF&}{\c&HCCFFCC&}楽しく{\c&HCCFFCC&}{\c&HFFFFCC&}やれ{\c&HFFFFCC&}{\c&HFFCCCC&}ば{\c&HFFCCCC&}{\c&HFFCCFF&}いい{\c&HFFCCFF&}{\c&HCCE5FF&}じゃ{\c&HCCE5FF&}{\c&HFFD8B1&}ねえ{\c&HFFD8B1&}{\c&HCCE0FF&}か{\c&HCCE0FF&}
+Dialogue: 0,0:14:06.36,0:14:09.13,Default-ja,,0,0,0,,{\c&HFFFFE0&}そう{\c&HFFFFE0&}{\c&HFFF0F5&}すごむ{\c&HFFF0F5&}なよ\N（魅音）甘い！
+Dialogue: 0,0:14:07.61,0:14:09.13,Default,,0,0,0,,{\c&HFFFFE0&}Weak{\c&HFFFFE0&} {\c&HFFF0F5&}!{\c&HFFF0F5&}
+Dialogue: 0,0:14:09.23,0:14:11.97,Default-ja,,0,0,0,,{\c&HFFE4E1&}会則{\c&HFFE4E1&}{\c&HFAFAD2&}第{\c&HFAFAD2&}{\c&HFFFACD&}１{\c&HFFFACD&}{\c&HFFEFD5&}条{\c&HFFEFD5&}{\c&HFFFFF0&}“{\c&HFFFFF0&}{\c&HFFF5EE&}狙う{\c&HFFF5EE&}{\c&HFAEBD7&}の{\c&HFAEBD7&}は１位のみ”
+Dialogue: 0,0:14:09.24,0:14:11.91,Default,,0,0,0,,{\c&HFFE4E1&}Article{\c&HFFE4E1&} {\c&HFAFAD2&}1:{\c&HFAFAD2&} {\c&HFFFACD&}Strive{\c&HFFFACD&} {\c&HFFEFD5&}only{\c&HFFEFD5&} {\c&HFFFFF0&}for{\c&HFFFFF0&} {\c&HFFF5EE&}first{\c&HFFF5EE&} {\c&HFAEBD7&}!{\c&HFAEBD7&}
+Dialogue: 0,0:14:12.01,0:14:14.78,Default,,0,0,0,,{\c&HFFFAFA&}I{\c&HFFFAFA&} {\c&HCCFFFF&}won't{\c&HCCFFFF&} {\c&HFFFFFF&}allow{\c&HFFFFFF&} {\c&HCCFFFF&}that{\c&HCCFFFF&} {\c&HCCFFCC&}\{\c&HCCFFCC&} {\c&HFFFFCC&}Nstance{\c&HFFFFCC&} {\c&HFFCCCC&}in{\c&HFFCCCC&} {\c&HFFCCFF&}a{\c&HFFCCFF&} {\c&HCCE5FF&}game{\c&HCCE5FF&} {\c&HFFD8B1&}!{\c&HFFD8B1&}
+Dialogue: 0,0:14:12.07,0:14:14.94,Default-ja,,0,0,0,,{\c&HFFFAFA&}“{\c&HFFFAFA&}{\c&HCCFFFF&}遊び{\c&HCCFFFF&}{\c&HFFFFFF&}だ{\c&HFFFFFF&}{\c&HCCFFFF&}から{\c&HCCFFFF&}{\c&HCCFFCC&}”{\c&HCCFFCC&}{\c&HFFFFCC&}なん{\c&HFFFFCC&}{\c&HFFCCCC&}ていう{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}{\c&HFFD8B1&}いいかげん{\c&HFFD8B1&}なプレーは許さない！
+Dialogue: 0,0:14:15.02,0:14:20.35,Default,,0,0,0,,{\c&HCCE0FF&}Article{\c&HCCE0FF&} {\c&HFFFFE0&}2:{\c&HFFFFE0&} {\c&HFFF0F5&}To{\c&HFFF0F5&} {\c&HFFE4E1&}do{\c&HFFE4E1&} {\c&HFAFAD2&}that{\c&HFAFAD2&} {\c&HFFFACD&},{\c&HFFFACD&} {\c&HFFEFD5&}putting{\c&HFFEFD5&} {\c&HFFFFF0&}forth{\c&HFFFFF0&} {\c&HFFF5EE&}\{\c&HFFF5EE&} {\c&HFAEBD7&}Nall{\c&HFAEBD7&} {\c&HFFFAFA&}possible{\c&HFFFAFA&} {\c&HCCFFFF&}effort{\c&HCCFFFF&} {\c&HFFFFFF&}is{\c&HFFFFFF&} {\c&HCCFFFF&}required{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:14:15.07,0:14:18.71,Default-ja,,0,0,0,,{\c&HCCE0FF&}会則{\c&HCCE0FF&}{\c&HFFFFE0&}第{\c&HFFFFE0&}{\c&HFFF0F5&}２{\c&HFFF0F5&}{\c&HFFE4E1&}条{\c&HFFE4E1&}{\c&HFAFAD2&}“{\c&HFAFAD2&}{\c&HFFFACD&}その{\c&HFFFACD&}{\c&HFFEFD5&}ため{\c&HFFEFD5&}{\c&HFFFFF0&}に{\c&HFFFFF0&}{\c&HFFF5EE&}は{\c&HFFF5EE&}{\c&HFAEBD7&}\{\c&HFAEBD7&}{\c&HFFFAFA&}N{\c&HFFFAFA&}{\c&HCCFFFF&}あらゆる{\c&HCCFFFF&}{\c&HFFFFFF&}努力{\c&HFFFFFF&}{\c&HCCFFFF&}を{\c&HCCFFFF&}{\c&HCCFFCC&}する{\c&HCCFFCC&}こと”が―
+Dialogue: 0,0:14:18.81,0:14:21.91,Default-ja,,0,0,0,,{\c&HFFFFCC&}義務づけ{\c&HFFFFCC&}{\c&HFFCCCC&}られ{\c&HFFCCCC&}{\c&HFFCCFF&}て{\c&HFFCCFF&}{\c&HCCE5FF&}おり{\c&HCCE5FF&}ますのよ\N（圭一）分かった分かった
+Dialogue: 0,0:14:20.45,0:14:21.79,Default,,0,0,0,,{\c&HFFFFCC&}I{\c&HFFFFCC&} {\c&HFFCCCC&}get{\c&HFFCCCC&} {\c&HFFCCFF&}it{\c&HFFCCFF&} {\c&HCCE5FF&}.{\c&HCCE5FF&}
+Dialogue: 0,0:14:22.26,0:14:26.75,Default,,0,0,0,,{\c&HFFD8B1&}Complex{\c&HFFD8B1&} {\c&HCCE0FF&}games{\c&HCCE0FF&} {\c&HFFFFE0&}will{\c&HFFFFE0&} {\c&HFFF0F5&}put{\c&HFFF0F5&} {\c&HFFE4E1&}\{\c&HFFE4E1&} {\c&HFAFAD2&}Nhim{\c&HFAFAD2&} {\c&HFFFACD&}at{\c&HFFFACD&} {\c&HFFEFD5&}a{\c&HFFEFD5&} {\c&HFFFFF0&}disadvantage{\c&HFFFFF0&} {\c&HFFF5EE&}...{\c&HFFF5EE&}
+Dialogue: 0,0:14:22.31,0:14:26.75,Default-ja,,0,0,0,,{\c&HFFD8B1&}じゃ{\c&HFFD8B1&}{\c&HCCE0FF&}難しい{\c&HCCE0FF&}{\c&HFFFFE0&}ゲーム{\c&HFFFFE0&}{\c&HFFF0F5&}は{\c&HFFF0F5&}{\c&HFFE4E1&}\{\c&HFFE4E1&}{\c&HFAFAD2&}N{\c&HFAFAD2&}{\c&HFFFACD&}圭{\c&HFFFACD&}{\c&HFFEFD5&}ちゃん{\c&HFFEFD5&}{\c&HFFFFF0&}に{\c&HFFFFF0&}{\c&HFFF5EE&}不利{\c&HFFF5EE&}になるから…
+Dialogue: 0,0:14:26.86,0:14:30.59,Default,,0,0,0,,{\c&HFAEBD7&}...{\c&HFAEBD7&} {\c&HFFFAFA&}so{\c&HFFFAFA&} {\c&HCCFFFF&}let's{\c&HCCFFFF&} {\c&HFFFFFF&}play{\c&HFFFFFF&} {\c&HCCFFFF&}a{\c&HCCFFFF&} {\c&HCCFFCC&}game{\c&HCCFFCC&} {\c&HFFFFCC&}\{\c&HFFFFCC&} {\c&HFFCCCC&}Neverybody{\c&HFFCCCC&} {\c&HFFCCFF&}understands{\c&HFFCCFF&} {\c&HCCE5FF&}.{\c&HCCE5FF&}
+Dialogue: 0,0:14:26.95,0:14:29.99,Default-ja,,0,0,0,,{\c&HFAEBD7&}今日{\c&HFAEBD7&}{\c&HFFFAFA&}は{\c&HFFFAFA&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}{\c&HCCFFFF&}誰{\c&HCCFFFF&}{\c&HCCFFCC&}に{\c&HCCFFCC&}{\c&HFFFFCC&}でも{\c&HFFFFCC&}{\c&HFFCCCC&}分かる{\c&HFFCCCC&}{\c&HFFCCFF&}ゲーム{\c&HFFCCFF&}{\c&HCCE5FF&}に{\c&HCCE5FF&}しよう
+Dialogue: 0,0:14:30.70,0:14:33.72,Default,,0,0,0,,{\c&HFFD8B1&}How{\c&HFFD8B1&} {\c&HCCE0FF&}about{\c&HCCE0FF&} {\c&HFFFFE0&}ordinary{\c&HFFFFE0&} {\c&HFFF0F5&}old{\c&HFFF0F5&} {\c&HFFE4E1&}maid{\c&HFFE4E1&} {\c&HFAFAD2&}?{\c&HFAFAD2&}
+Dialogue: 0,0:14:30.85,0:14:33.49,Default-ja,,0,0,0,,{\c&HFFD8B1&}スタンダード{\c&HFFD8B1&}{\c&HCCE0FF&}に{\c&HCCE0FF&}{\c&HFFFFE0&}\{\c&HFFFFE0&}{\c&HFFF0F5&}N{\c&HFFF0F5&}{\c&HFFE4E1&}トランプ{\c&HFFE4E1&}{\c&HFAFAD2&}の{\c&HFAFAD2&}ジジ抜きはどう？
+Dialogue: 0,0:14:33.79,0:14:34.83,Default-ja,,0,0,0,,{\c&HFFFACD&}（{\c&HFFFACD&}{\c&HFFEFD5&}圭一{\c&HFFEFD5&}{\c&HFFFFF0&}）{\c&HFFFFF0&}{\c&HFFF5EE&}余裕{\c&HFFF5EE&}だぜ！
+Dialogue: 0,0:14:33.83,0:14:35.46,Default,,0,0,0,,{\c&HFFFACD&}Piece{\c&HFFFACD&} {\c&HFFEFD5&}of{\c&HFFEFD5&} {\c&HFFFFF0&}cake{\c&HFFFFF0&} {\c&HFFF5EE&}.{\c&HFFF5EE&}
+Dialogue: 0,0:14:36.17,0:14:40.27,Default,,0,0,0,,{\c&HFAEBD7&}For{\c&HFAEBD7&} {\c&HFFFAFA&}a{\c&HFFFAFA&} {\c&HCCFFFF&}punishment{\c&HCCFFFF&} {\c&HFFFFFF&}game{\c&HFFFFFF&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HCCFFCC&}first{\c&HCCFFCC&} {\c&HFFFFCC&}\{\c&HFFFFCC&} {\c&HFFCCCC&}Nplace{\c&HFFCCCC&} {\c&HFFCCFF&}can{\c&HFFCCFF&} {\c&HCCE5FF&}order{\c&HCCE5FF&} {\c&HFFD8B1&}last{\c&HFFD8B1&} {\c&HCCE0FF&}place{\c&HCCE0FF&} {\c&HFFFFE0&}around{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:14:36.19,0:14:39.90,Default-ja,,0,0,0,,{\c&HFAEBD7&}（{\c&HFAEBD7&}{\c&HFFFAFA&}魅{\c&HFFFAFA&}{\c&HCCFFFF&}音{\c&HCCFFFF&}{\c&HFFFFFF&}）{\c&HFFFFFF&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HCCFFCC&}N{\c&HCCFFCC&}{\c&HFFFFCC&}罰{\c&HFFFFCC&}{\c&HFFCCCC&}ゲーム{\c&HFFCCCC&}{\c&HFFCCFF&}は{\c&HFFCCFF&}{\c&HCCE5FF&}１{\c&HCCE5FF&}{\c&HFFD8B1&}位{\c&HFFD8B1&}{\c&HCCE0FF&}が{\c&HCCE0FF&}{\c&HFFFFE0&}ビリ{\c&HFFFFE0&}{\c&HFFF0F5&}に{\c&HFFF0F5&}１コ命令
+Dialogue: 0,0:14:40.36,0:14:41.43,Default-ja,,0,0,0,,{\c&HFFE4E1&}この{\c&HFFE4E1&}{\c&HFAFAD2&}辺{\c&HFAFAD2&}{\c&HFFFACD&}で{\c&HFFFACD&}どうかな？
+Dialogue: 0,0:14:40.37,0:14:41.40,Default,,0,0,0,,{\c&HFFE4E1&}How's{\c&HFFE4E1&} {\c&HFAFAD2&}that{\c&HFAFAD2&} {\c&HFFFACD&}?{\c&HFFFACD&}
+Dialogue: 0,0:14:41.81,0:14:43.50,Default,,0,0,0,,{\c&HFFEFD5&}Bring{\c&HFFEFD5&} {\c&HFFFFF0&}it{\c&HFFFFF0&} {\c&HFFF5EE&}on{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:14:41.90,0:14:43.50,Default-ja,,0,0,0,,{\c&HFFEFD5&}上等{\c&HFFEFD5&}{\c&HFFFFF0&}で{\c&HFFFFF0&}{\c&HFFF5EE&}ござい{\c&HFFF5EE&}{\c&HFAEBD7&}ます{\c&HFAEBD7&}わ
+Dialogue: 0,0:14:44.01,0:14:46.64,Default,,0,0,0,,{\c&HFFFAFA&}Okay{\c&HFFFAFA&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HFFFFFF&}let's{\c&HFFFFFF&} {\c&HCCFFFF&}shuffle{\c&HCCFFFF&} {\c&HCCFFCC&}the{\c&HCCFFCC&} {\c&HFFFFCC&}cards{\c&HFFFFCC&} {\c&HFFCCCC&}.{\c&HFFCCCC&}
+Dialogue: 0,0:14:44.07,0:14:46.77,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}魅{\c&HCCFFFF&}{\c&HFFFFFF&}音{\c&HFFFFFF&}{\c&HCCFFFF&}）{\c&HCCFFFF&}{\c&HCCFFCC&}じゃ{\c&HCCFFCC&}{\c&HFFFFCC&}カード{\c&HFFFFCC&}{\c&HFFCCCC&}を{\c&HFFCCCC&}切って…
+Dialogue: 0,0:14:48.34,0:14:49.51,Default-ja,,0,0,0,,{\c&HFFCCFF&}（{\c&HFFCCFF&}{\c&HCCE5FF&}ﾚﾅ{\c&HCCE5FF&}{\c&HFFD8B1&}）{\c&HFFD8B1&}{\c&HCCE0FF&}１{\c&HCCE0FF&}{\c&HFFFFE0&}枚{\c&HFFFFE0&}抜くね
+Dialogue: 0,0:14:48.35,0:14:50.32,Default,,0,0,0,,{\c&HFFCCFF&}I'll{\c&HFFCCFF&} {\c&HCCE5FF&}take{\c&HCCE5FF&} {\c&HFFD8B1&}this{\c&HFFD8B1&} {\c&HCCE0FF&}one{\c&HCCE0FF&} {\c&HFFFFE0&}.{\c&HFFFFE0&}
+Dialogue: 0,0:14:50.75,0:14:53.52,Default,,0,0,0,,{\c&HFFF0F5&}These{\c&HFFF0F5&} {\c&HFFE4E1&}cards{\c&HFFE4E1&} {\c&HFAFAD2&}are{\c&HFAFAD2&} {\c&HFFFACD&}pretty{\c&HFFFACD&} {\c&HFFEFD5&}worn{\c&HFFEFD5&} {\c&HFFFFF0&}.{\c&HFFFFF0&}
+Dialogue: 0,0:14:50.87,0:14:55.01,Default-ja,,0,0,0,,{\c&HFFF0F5&}この{\c&HFFF0F5&}{\c&HFFE4E1&}トランプ{\c&HFFE4E1&}{\c&HFAFAD2&}結構{\c&HFAFAD2&}{\c&HFFFACD&}傷物{\c&HFFFACD&}{\c&HFFEFD5&}だ{\c&HFFEFD5&}{\c&HFFFFF0&}な{\c&HFFFFF0&}\Nまさかみんなには―
+Dialogue: 0,0:14:53.62,0:14:58.02,Default,,0,0,0,,{\c&HFFF5EE&}Don't{\c&HFFF5EE&} {\c&HFAEBD7&}tell{\c&HFAEBD7&} {\c&HFFFAFA&}me{\c&HFFFAFA&} {\c&HCCFFFF&}you{\c&HCCFFFF&} {\c&HFFFFFF&}all{\c&HFFFFFF&} {\c&HCCFFFF&}know{\c&HCCFFFF&} {\c&HCCFFCC&}which{\c&HCCFFCC&} {\c&HFFFFCC&}\{\c&HFFFFCC&} {\c&HFFCCCC&}Ncard{\c&HFFCCCC&} {\c&HFFCCFF&}is{\c&HFFCCFF&} {\c&HCCE5FF&}which{\c&HCCE5FF&} {\c&HFFD8B1&}from{\c&HFFD8B1&} {\c&HCCE0FF&}the{\c&HCCE0FF&} {\c&HFFFFE0&}scratches{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:14:55.11,0:14:58.12,Default-ja,,0,0,0,,{\c&HFFF5EE&}その{\c&HFFF5EE&}{\c&HFAEBD7&}傷{\c&HFAEBD7&}{\c&HFFFAFA&}で{\c&HFFFAFA&}{\c&HCCFFFF&}そこ{\c&HCCFFFF&}{\c&HFFFFFF&}に{\c&HFFFFFF&}{\c&HCCFFFF&}伏せ{\c&HCCFFFF&}{\c&HCCFFCC&}た{\c&HCCFFCC&}{\c&HFFFFCC&}カード{\c&HFFFFCC&}{\c&HFFCCCC&}が{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}{\c&HFFD8B1&}分かっ{\c&HFFD8B1&}{\c&HCCE0FF&}てる{\c&HCCE0FF&}{\c&HFFFFE0&}とか{\c&HFFFFE0&}{\c&HFFF0F5&}？{\c&HFFF0F5&}
+Dialogue: 0,0:14:59.05,0:15:02.02,Default-ja,,0,0,0,,{\c&HFFE4E1&}（{\c&HFFE4E1&}{\c&HFAFAD2&}ﾚﾅ{\c&HFAFAD2&}{\c&HFFFACD&}たち{\c&HFFFACD&}{\c&HFFEFD5&}）{\c&HFFEFD5&}{\c&HFFFFF0&}ヘヘヘヘッ{\c&HFFFFF0&}…\N（圭一）ちょ…ちょっと待て！
+Dialogue: 0,0:14:59.96,0:15:01.99,Default,,0,0,0,,{\c&HFFE4E1&}H{\c&HFFE4E1&} {\c&HFAFAD2&}-{\c&HFAFAD2&} {\c&HFFFACD&}Hold{\c&HFFFACD&} {\c&HFFEFD5&}on{\c&HFFEFD5&} {\c&HFFFFF0&}!{\c&HFFFFF0&}
+Dialogue: 0,0:15:02.10,0:15:03.43,Default,,0,0,0,,{\c&HFFF5EE&}That's{\c&HFFF5EE&} {\c&HFAEBD7&}not{\c&HFAEBD7&} {\c&HFFFAFA&}fair{\c&HFFFAFA&} {\c&HCCFFFF&}!{\c&HCCFFFF&}
+Dialogue: 0,0:15:02.12,0:15:03.45,Default-ja,,0,0,0,,{\c&HFFF5EE&}そんな{\c&HFFF5EE&}{\c&HFAEBD7&}ん{\c&HFAEBD7&}{\c&HFFFAFA&}あり{\c&HFFFAFA&}{\c&HCCFFFF&}か{\c&HCCFFFF&}よ！
+Dialogue: 0,0:15:04.06,0:15:08.59,Default,,0,0,0,,{\c&HFFFFFF&}Article{\c&HFFFFFF&} {\c&HCCFFFF&}2:{\c&HCCFFFF&} {\c&HCCFFCC&}Putting{\c&HCCFFCC&} {\c&HFFFFCC&}forth{\c&HFFFFCC&} {\c&HFFCCCC&}all{\c&HFFCCCC&} {\c&HFFCCFF&}\{\c&HFFCCFF&} {\c&HCCE5FF&}Npossible{\c&HCCE5FF&} {\c&HFFD8B1&}effort{\c&HFFD8B1&} {\c&HCCE0FF&}is{\c&HCCE0FF&} {\c&HFFFFE0&}required{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:15:04.12,0:15:08.49,Default-ja,,0,0,0,,{\c&HFFFFFF&}会則{\c&HFFFFFF&}{\c&HCCFFFF&}第{\c&HCCFFFF&}{\c&HCCFFCC&}２{\c&HCCFFCC&}{\c&HFFFFCC&}条{\c&HFFFFCC&}{\c&HFFCCCC&}“{\c&HFFCCCC&}{\c&HFFCCFF&}勝つ{\c&HFFCCFF&}{\c&HCCE5FF&}ため{\c&HCCE5FF&}{\c&HFFD8B1&}に{\c&HFFD8B1&}{\c&HCCE0FF&}は{\c&HCCE0FF&}{\c&HFFFFE0&}\{\c&HFFFFE0&}{\c&HFFF0F5&}N{\c&HFFF0F5&}あらゆる努力をすること”ですわ
+Dialogue: 0,0:15:08.70,0:15:13.54,Default,,0,0,0,,{\c&HFFE4E1&}Some{\c&HFFE4E1&} {\c&HFAFAD2&}cards{\c&HFAFAD2&} {\c&HFFFACD&}are{\c&HFFFACD&} {\c&HFFEFD5&}really{\c&HFFEFD5&} {\c&HFFFFF0&}distinct{\c&HFFFFF0&} {\c&HFFF5EE&},\{\c&HFFF5EE&} {\c&HFAEBD7&}Nso{\c&HFAEBD7&} {\c&HFFFAFA&}you'll{\c&HFFFAFA&} {\c&HCCFFFF&}notice{\c&HCCFFFF&} {\c&HFFFFFF&}them{\c&HFFFFFF&} {\c&HCCFFFF&}fast{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:15:08.83,0:15:13.50,Default-ja,,0,0,0,,{\c&HFFE4E1&}いくつ{\c&HFFE4E1&}{\c&HFAFAD2&}か{\c&HFAFAD2&}{\c&HFFFACD&}の{\c&HFFFACD&}{\c&HFFEFD5&}カード{\c&HFFEFD5&}{\c&HFFFFF0&}は{\c&HFFFFF0&}{\c&HFFF5EE&}特徴{\c&HFFF5EE&}{\c&HFAEBD7&}的{\c&HFAEBD7&}{\c&HFFFAFA&}だ{\c&HFFFAFA&}{\c&HCCFFFF&}から{\c&HCCFFFF&}{\c&HFFFFFF&}\{\c&HFFFFFF&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HCCFFCC&}圭一{\c&HCCFFCC&}君もすぐに覚えられるよ
+Dialogue: 0,0:15:13.64,0:15:17.94,Default,,0,0,0,,{\c&HFFFFCC&}B{\c&HFFFFCC&} {\c&HFFCCCC&}-{\c&HFFCCCC&} {\c&HFFCCFF&}Bring{\c&HFFCCFF&} {\c&HCCE5FF&}it{\c&HCCE5FF&} {\c&HFFD8B1&}on{\c&HFFD8B1&} {\c&HCCE0FF&}!{\c&HCCE0FF&} {\c&HFFFFE0&}Don't{\c&HFFFFE0&} {\c&HFFF0F5&}think{\c&HFFF0F5&} {\c&HFFE4E1&}\{\c&HFFE4E1&} {\c&HFAFAD2&}Nthat{\c&HFAFAD2&} {\c&HFFFACD&}this'll{\c&HFFFACD&} {\c&HFFEFD5&}be{\c&HFFEFD5&} {\c&HFFFFF0&}a{\c&HFFFFF0&} {\c&HFFF5EE&}handicap{\c&HFFF5EE&} {\c&HFAEBD7&}!{\c&HFAEBD7&}
+Dialogue: 0,0:15:13.80,0:15:18.07,Default-ja,,0,0,0,,{\c&HFFFFCC&}じ{\c&HFFFFCC&}{\c&HFFCCCC&}ょ{\c&HFFCCCC&}{\c&HFFCCFF&}…{\c&HFFCCFF&}{\c&HCCE5FF&}上等{\c&HCCE5FF&}{\c&HFFD8B1&}だ{\c&HFFD8B1&}{\c&HCCE0FF&}ぜ{\c&HCCE0FF&}{\c&HFFFFE0&}\{\c&HFFFFE0&}{\c&HFFF0F5&}N{\c&HFFF0F5&}{\c&HFFE4E1&}この{\c&HFFE4E1&}{\c&HFAFAD2&}程度{\c&HFAFAD2&}{\c&HFFFACD&}で{\c&HFFFACD&}{\c&HFFEFD5&}ハンデ{\c&HFFEFD5&}{\c&HFFFFF0&}に{\c&HFFFFF0&}{\c&HFFF5EE&}なる{\c&HFFF5EE&}{\c&HFAEBD7&}と{\c&HFAEBD7&}思うなよ
+Dialogue: 0,0:15:25.28,0:15:29.55,Default-ja,,0,0,0,,{\c&HFFFAFA&}ハハハッ{\c&HFFFAFA&}{\c&HCCFFFF&}！\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}{\c&HCCFFFF&}圭{\c&HCCFFFF&}{\c&HCCFFCC&}ちゃん{\c&HCCFFCC&}{\c&HFFFFCC&}の{\c&HFFFFCC&}{\c&HFFCCCC&}手札{\c&HFFCCCC&}{\c&HFFCCFF&}を{\c&HFFCCFF&}{\c&HCCE5FF&}右{\c&HCCE5FF&}{\c&HFFD8B1&}から{\c&HFFD8B1&}言うよ
+Dialogue: 0,0:15:27.05,0:15:29.89,Default,,0,0,0,,{\c&HFFFAFA&}I'll{\c&HFFFAFA&} {\c&HCCFFFF&}read{\c&HCCFFFF&} {\c&HFFFFFF&}your{\c&HFFFFFF&} {\c&HCCFFFF&}cards{\c&HCCFFFF&} {\c&HCCFFCC&}\{\c&HCCFFCC&} {\c&HFFFFCC&}Nfrom{\c&HFFFFCC&} {\c&HFFCCCC&}right{\c&HFFCCCC&} {\c&HFFCCFF&}to{\c&HFFCCFF&} {\c&HCCE5FF&}left{\c&HCCE5FF&} {\c&HFFD8B1&}.{\c&HFFD8B1&}
+Dialogue: 0,0:15:29.99,0:15:32.55,Default,,0,0,0,,{\c&HCCE0FF&}Three{\c&HCCE0FF&} {\c&HFFFFE0&},{\c&HFFFFE0&} {\c&HFFF0F5&}four{\c&HFFF0F5&} {\c&HFFE4E1&},{\c&HFFE4E1&} {\c&HFAFAD2&}nine{\c&HFAFAD2&} {\c&HFFFACD&},{\c&HFFFACD&} {\c&HFFEFD5&}jack{\c&HFFEFD5&} {\c&HFFFFF0&},{\c&HFFFFF0&} {\c&HFFF5EE&}queen{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:15:30.05,0:15:32.55,Default-ja,,0,0,0,,{\c&HCCE0FF&}（{\c&HCCE0FF&}{\c&HFFFFE0&}魅{\c&HFFFFE0&}{\c&HFFF0F5&}音{\c&HFFF0F5&}{\c&HFFE4E1&}）{\c&HFFE4E1&}{\c&HFAFAD2&}\{\c&HFAFAD2&}{\c&HFFFACD&}N{\c&HFFFACD&}{\c&HFFEFD5&}３{\c&HFFEFD5&}{\c&HFFFFF0&}４{\c&HFFFFF0&}{\c&HFFF5EE&}９{\c&HFFF5EE&}{\c&HFAEBD7&}ジャック{\c&HFAEBD7&}クイーン
+Dialogue: 0,0:15:32.88,0:15:33.55,Default-ja,,0,0,0,,{\c&HFFFAFA&}グワーッ{\c&HFFFAFA&}{\c&HCCFFFF&}！{\c&HCCFFFF&}
+Dialogue: 0,0:15:33.89,0:15:37.02,Default,,0,0,0,,{\c&HFFFAFA&}By{\c&HFFFAFA&} {\c&HCCFFFF&}the{\c&HCCFFFF&} way , the odd card \ Nis the jack of diamonds .
 Dialogue: 0,0:15:34.02,0:15:37.15,Default-ja,,0,0,0,,ちなみに\Nジジは ダイヤのジャックなのです
 Dialogue: 0,0:15:37.29,0:15:38.16,Default-ja,,0,0,0,,ウワーッ！
-Dialogue: 0,0:15:38.29,0:15:41.56,Default-ja,,0,0,0,,どうカードを入れ替えたって\N見え見えですわ
-Dialogue: 0,0:15:38.70,0:15:42.53,Default,,0,0,0,,It doesn't matter how you\Nshuffle them, I can still tell.
-Dialogue: 0,0:15:41.86,0:15:42.53,Default-ja,,0,0,0,,フフン…
-Dialogue: 0,0:15:43.00,0:15:44.03,Default,,0,0,0,,I'm out!
+Dialogue: 0,0:15:38.29,0:15:41.56,Default-ja,,0,0,0,,{\c&HFFFFFF&}どう{\c&HFFFFFF&}{\c&HCCFFFF&}カード{\c&HCCFFFF&}{\c&HCCFFCC&}を{\c&HCCFFCC&}{\c&HFFFFCC&}入れ替え{\c&HFFFFCC&}{\c&HFFCCCC&}た{\c&HFFCCCC&}{\c&HFFCCFF&}って{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}見え{\c&HCCE0FF&}{\c&HFFFFE0&}見え{\c&HFFFFE0&}{\c&HFFF0F5&}です{\c&HFFF0F5&}{\c&HFFE4E1&}わ{\c&HFFE4E1&}
+Dialogue: 0,0:15:38.70,0:15:42.53,Default,,0,0,0,,{\c&HFFFFFF&}It{\c&HFFFFFF&} {\c&HCCFFFF&}doesn't{\c&HCCFFFF&} {\c&HCCFFCC&}matter{\c&HCCFFCC&} {\c&HFFFFCC&}how{\c&HFFFFCC&} {\c&HFFCCCC&}you{\c&HFFCCCC&} {\c&HFFCCFF&}\{\c&HFFCCFF&} {\c&HCCE5FF&}Nshuffle{\c&HCCE5FF&} {\c&HFFD8B1&}them{\c&HFFD8B1&} {\c&HCCE0FF&},{\c&HCCE0FF&} {\c&HFFFFE0&}I{\c&HFFFFE0&} {\c&HFFF0F5&}can{\c&HFFF0F5&} {\c&HFFE4E1&}still{\c&HFFE4E1&} tell .
+Dialogue: 0,0:15:41.86,0:15:42.53,Default-ja,,0,0,0,,{\c&HFAFAD2&}フフン{\c&HFAFAD2&}{\c&HFFFACD&}…{\c&HFFFACD&}
+Dialogue: 0,0:15:43.00,0:15:44.03,Default,,0,0,0,,{\c&HFAFAD2&}I'm{\c&HFAFAD2&} {\c&HFFFACD&}out{\c&HFFFACD&} !
 Dialogue: 0,0:15:43.09,0:15:44.16,Default-ja,,0,0,0,,（梨花）上がりですの！
-Dialogue: 0,0:15:46.40,0:15:50.37,Default-ja,,0,0,0,,お… 鬼だ　こいつらは鬼だ…
-Dialogue: 0,0:15:46.44,0:15:48.34,Default,,0,0,0,,Y-You're evil.
+Dialogue: 0,0:15:46.40,0:15:50.37,Default-ja,,0,0,0,,{\c&HFFEFD5&}お{\c&HFFEFD5&}{\c&HFFFFF0&}…{\c&HFFFFF0&}{\c&HFFF5EE&}鬼{\c&HFFF5EE&}{\c&HFAEBD7&}だ{\c&HFAEBD7&}{\c&HFFFAFA&}　{\c&HFFFAFA&}こいつらは鬼だ…
+Dialogue: 0,0:15:46.44,0:15:48.34,Default,,0,0,0,,{\c&HFFEFD5&}Y{\c&HFFEFD5&} {\c&HFFFFF0&}-{\c&HFFFFF0&} {\c&HFFF5EE&}You're{\c&HFFF5EE&} {\c&HFAEBD7&}evil{\c&HFAEBD7&} {\c&HFFFAFA&}.{\c&HFFFAFA&}
 Dialogue: 0,0:15:48.44,0:15:50.31,Default,,0,0,0,,Just evil.
-Dialogue: 0,0:15:51.81,0:15:53.78,Default,,0,0,0,,Rena's not evil, right?
-Dialogue: 0,0:15:51.90,0:15:53.54,Default-ja,,0,0,0,,レナは鬼じゃないよな？
-Dialogue: 0,0:15:53.88,0:15:56.37,Default,,0,0,0,,S-Sorry, Keiichi-kun.
-Dialogue: 0,0:15:54.00,0:15:56.37,Default-ja,,0,0,0,,ご… ごめんね 圭一君
-Dialogue: 0,0:15:56.47,0:15:58.94,Default-ja,,0,0,0,,こっちが\Nハートの３だよね？
-Dialogue: 0,0:15:56.48,0:15:58.97,Default,,0,0,0,,This is the three of hearts, right?
-Dialogue: 0,0:15:59.04,0:15:59.91,Default-ja,,0,0,0,,上がり！
-Dialogue: 0,0:15:59.09,0:16:00.55,Default,,0,0,0,,I'm out.
+Dialogue: 0,0:15:51.81,0:15:53.78,Default,,0,0,0,,{\c&HCCFFFF&}Rena's{\c&HCCFFFF&} {\c&HFFFFFF&}not{\c&HFFFFFF&} {\c&HCCFFFF&}evil{\c&HCCFFFF&} {\c&HCCFFCC&},{\c&HCCFFCC&} {\c&HFFFFCC&}right{\c&HFFFFCC&} {\c&HFFCCCC&}?{\c&HFFCCCC&}
+Dialogue: 0,0:15:51.90,0:15:53.54,Default-ja,,0,0,0,,{\c&HCCFFFF&}レナ{\c&HCCFFFF&}{\c&HFFFFFF&}は{\c&HFFFFFF&}{\c&HCCFFFF&}鬼{\c&HCCFFFF&}{\c&HCCFFCC&}じゃ{\c&HCCFFCC&}{\c&HFFFFCC&}ない{\c&HFFFFCC&}{\c&HFFCCCC&}よ{\c&HFFCCCC&}な？
+Dialogue: 0,0:15:53.88,0:15:56.37,Default,,0,0,0,,{\c&HFFCCFF&}S{\c&HFFCCFF&} {\c&HCCE5FF&}-{\c&HCCE5FF&} {\c&HFFD8B1&}Sorry{\c&HFFD8B1&} {\c&HCCE0FF&},{\c&HCCE0FF&} {\c&HFFFFE0&}Keiichi{\c&HFFFFE0&} {\c&HFFF0F5&}-{\c&HFFF0F5&} kun .
+Dialogue: 0,0:15:54.00,0:15:56.37,Default-ja,,0,0,0,,{\c&HFFCCFF&}ご{\c&HFFCCFF&}{\c&HCCE5FF&}…{\c&HCCE5FF&}{\c&HFFD8B1&}ごめん{\c&HFFD8B1&}{\c&HCCE0FF&}ね{\c&HCCE0FF&}{\c&HFFFFE0&}圭一{\c&HFFFFE0&}{\c&HFFF0F5&}君{\c&HFFF0F5&}
+Dialogue: 0,0:15:56.47,0:15:58.94,Default-ja,,0,0,0,,{\c&HFFE4E1&}こっち{\c&HFFE4E1&}{\c&HFAFAD2&}が{\c&HFAFAD2&}{\c&HFFFACD&}\{\c&HFFFACD&}{\c&HFFEFD5&}N{\c&HFFEFD5&}{\c&HFFFFF0&}ハート{\c&HFFFFF0&}{\c&HFFF5EE&}の{\c&HFFF5EE&}{\c&HFAEBD7&}３{\c&HFAEBD7&}{\c&HFFFAFA&}だ{\c&HFFFAFA&}{\c&HCCFFFF&}よ{\c&HCCFFFF&}ね？
+Dialogue: 0,0:15:56.48,0:15:58.97,Default,,0,0,0,,{\c&HFFE4E1&}This{\c&HFFE4E1&} {\c&HFAFAD2&}is{\c&HFAFAD2&} {\c&HFFFACD&}the{\c&HFFFACD&} {\c&HFFEFD5&}three{\c&HFFEFD5&} {\c&HFFFFF0&}of{\c&HFFFFF0&} {\c&HFFF5EE&}hearts{\c&HFFF5EE&} {\c&HFAEBD7&},{\c&HFAEBD7&} {\c&HFFFAFA&}right{\c&HFFFAFA&} {\c&HCCFFFF&}?{\c&HCCFFFF&}
+Dialogue: 0,0:15:59.04,0:15:59.91,Default-ja,,0,0,0,,{\c&HFFFFFF&}上がり{\c&HFFFFFF&}{\c&HCCFFFF&}！{\c&HCCFFFF&}
+Dialogue: 0,0:15:59.09,0:16:00.55,Default,,0,0,0,,{\c&HFFFFFF&}I'm{\c&HFFFFFF&} {\c&HCCFFFF&}out{\c&HCCFFFF&} .
 Dialogue: 0,0:16:00.08,0:16:01.91,Default-ja,,0,0,0,,ウワーッ！
-Dialogue: 0,0:16:08.49,0:16:11.32,Default-ja,,0,0,0,,う～ん…\N（ﾚﾅ）や… やっぱりさ…
-Dialogue: 0,0:16:09.60,0:16:15.90,Default,,0,0,0,,It's unfair to him if we\Ndon't play with a new deck...
-Dialogue: 0,0:16:11.59,0:16:15.96,Default-ja,,0,0,0,,きれいなトランプで やらないと\N圭一君に不公平だよ
-Dialogue: 0,0:16:16.00,0:16:19.40,Default,,0,0,0,,It's fine. He's a man.
+Dialogue: 0,0:16:08.49,0:16:11.32,Default-ja,,0,0,0,,{\c&HCCFFCC&}う{\c&HCCFFCC&}{\c&HFFFFCC&}～{\c&HFFFFCC&}{\c&HFFCCCC&}ん{\c&HFFCCCC&}{\c&HFFCCFF&}…{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}（{\c&HCCE0FF&}{\c&HFFFFE0&}ﾚﾅ{\c&HFFFFE0&}{\c&HFFF0F5&}）{\c&HFFF0F5&}{\c&HFFE4E1&}や{\c&HFFE4E1&}{\c&HFAFAD2&}…{\c&HFAFAD2&}{\c&HFFFACD&}やっぱり{\c&HFFFACD&}{\c&HFFEFD5&}さ{\c&HFFEFD5&}{\c&HFFFFF0&}…{\c&HFFFFF0&}
+Dialogue: 0,0:16:09.60,0:16:15.90,Default,,0,0,0,,{\c&HCCFFCC&}It's{\c&HCCFFCC&} {\c&HFFFFCC&}unfair{\c&HFFFFCC&} {\c&HFFCCCC&}to{\c&HFFCCCC&} {\c&HFFCCFF&}him{\c&HFFCCFF&} {\c&HCCE5FF&}if{\c&HCCE5FF&} {\c&HFFD8B1&}we{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}Ndon't{\c&HFFFFE0&} {\c&HFFF0F5&}play{\c&HFFF0F5&} {\c&HFFE4E1&}with{\c&HFFE4E1&} {\c&HFAFAD2&}a{\c&HFAFAD2&} {\c&HFFFACD&}new{\c&HFFFACD&} {\c&HFFEFD5&}deck{\c&HFFEFD5&} {\c&HFFFFF0&}...{\c&HFFFFF0&}
+Dialogue: 0,0:16:11.59,0:16:15.96,Default-ja,,0,0,0,,{\c&HFFF5EE&}きれい{\c&HFFF5EE&}{\c&HFAEBD7&}な{\c&HFAEBD7&}{\c&HFFFAFA&}トランプ{\c&HFFFAFA&}{\c&HCCFFFF&}で{\c&HCCFFFF&}{\c&HFFFFFF&}やら{\c&HFFFFFF&}{\c&HCCFFFF&}ない{\c&HCCFFFF&}{\c&HCCFFCC&}と{\c&HCCFFCC&}\N圭一君に不公平だよ
+Dialogue: 0,0:16:16.00,0:16:19.40,Default,,0,0,0,,{\c&HFFF5EE&}It's{\c&HFFF5EE&} {\c&HFAEBD7&}fine{\c&HFAEBD7&} {\c&HFFFAFA&}.{\c&HFFFAFA&} {\c&HCCFFFF&}He's{\c&HCCFFFF&} {\c&HFFFFFF&}a{\c&HFFFFFF&} {\c&HCCFFFF&}man{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
 Dialogue: 0,0:16:16.06,0:16:19.40,Default-ja,,0,0,0,,いいの いいの\N圭ちゃんだって男だし
-Dialogue: 0,0:16:19.50,0:16:21.60,Default-ja,,0,0,0,,これくらいの逆境は\Nはね返せるよね？
-Dialogue: 0,0:16:19.51,0:16:22.84,Default,,0,0,0,,I'm sure you can\Nendure some adversity.
-Dialogue: 0,0:16:22.94,0:16:24.91,Default,,0,0,0,,You can do it.
-Dialogue: 0,0:16:23.07,0:16:25.60,Default-ja,,0,0,0,,ファイト オーです\N（圭一）う～ん…
-Dialogue: 0,0:16:25.95,0:16:28.85,Default,,0,0,0,,Come on, Keiichi. Don't hide it.
-Dialogue: 0,0:16:26.07,0:16:29.01,Default-ja,,0,0,0,,ほら 圭ちゃん 隠さない隠さない
-Dialogue: 0,0:16:29.92,0:16:33.41,Default,,0,0,0,,This scratched one is\Nthe two of diamonds, right?
-Dialogue: 0,0:16:30.04,0:16:33.38,Default-ja,,0,0,0,,（魅音）\Nこの傷が確かダイヤの２だったよね
-Dialogue: 0,0:16:33.54,0:16:34.41,Default-ja,,0,0,0,,あれ？
-Dialogue: 0,0:16:33.89,0:16:34.85,Default,,0,0,0,,Huh?
-Dialogue: 0,0:16:34.88,0:16:39.08,Default-ja,,0,0,0,,あっ 魅ぃちゃんが\Nカード間違えるなんて珍しいね
-Dialogue: 0,0:16:35.79,0:16:39.02,Default,,0,0,0,,It's rare for you\Nto make a mistake, Mi-chan.
-Dialogue: 0,0:16:39.13,0:16:41.42,Default,,0,0,0,,T-That's not it. Kei-chan...
-Dialogue: 0,0:16:39.18,0:16:40.62,Default-ja,,0,0,0,,ち… 違う
-Dialogue: 0,0:16:40.92,0:16:43.32,Default-ja,,0,0,0,,圭ちゃん あんた まさか…
-Dialogue: 0,0:16:41.80,0:16:43.59,Default,,0,0,0,,Did you...
-Dialogue: 0,0:16:46.42,0:16:50.23,Default-ja,,0,0,0,,ハハハハッ！\N引っ掛かったな 園崎魅音！
-Dialogue: 0,0:16:48.27,0:16:50.74,Default,,0,0,0,,I got you, Mion Sonozaki!
-Dialogue: 0,0:16:50.84,0:16:54.14,Default,,0,0,0,,You somehow forged\Nthe two of diamonds?
-Dialogue: 0,0:16:50.93,0:16:53.43,Default-ja,,0,0,0,,ダイヤの２を\N偽装したというんですの？
-Dialogue: 0,0:16:53.53,0:16:56.63,Default-ja,,0,0,0,,あ… 味なマネを\Nするでございますわね
-Dialogue: 0,0:16:54.24,0:16:56.73,Default,,0,0,0,,You made a witty move.
-Dialogue: 0,0:16:56.84,0:17:00.14,Default,,0,0,0,,You got them back, Keiichi.
-Dialogue: 0,0:16:56.93,0:17:00.24,Default-ja,,0,0,0,,圭一 一矢を報いましたです\N（圭一）ヘヘッ！
-Dialogue: 0,0:17:00.75,0:17:04.65,Default,,0,0,0,,You did it! It was\Na close game! It was!
-Dialogue: 0,0:17:00.87,0:17:04.57,Default-ja,,0,0,0,,やったね 圭一君\N大善戦だよ！ だよ！
-Dialogue: 0,0:17:04.75,0:17:08.09,Default,,0,0,0,,I knew you could do it.
-Dialogue: 0,0:17:04.88,0:17:07.98,Default-ja,,0,0,0,,さすが\Nあたしが見込んだだけのことはある
-Dialogue: 0,0:17:08.19,0:17:11.65,Default,,0,0,0,,I never expected you\Nto think of something like this.
-Dialogue: 0,0:17:08.21,0:17:11.65,Default-ja,,0,0,0,,こんな手を思いつくとは\N圭ちゃん さすがだよ
-Dialogue: 0,0:17:11.98,0:17:13.15,Default-ja,,0,0,0,,ウフフッ…
-Dialogue: 0,0:17:13.23,0:17:16.39,Default,,0,0,0,,Except you're too late.
-Dialogue: 0,0:17:13.25,0:17:16.45,Default-ja,,0,0,0,,…とはいっても\Nちょっと手遅れだったようですわね
-Dialogue: 0,0:17:16.93,0:17:19.63,Default,,0,0,0,,I'm pretty much\Nset in last place...
+Dialogue: 0,0:16:19.50,0:16:21.60,Default-ja,,0,0,0,,{\c&HFFFFCC&}これ{\c&HFFFFCC&}{\c&HFFCCCC&}くらい{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}{\c&HCCE5FF&}逆境{\c&HCCE5FF&}{\c&HFFD8B1&}は{\c&HFFD8B1&}{\c&HCCE0FF&}\{\c&HCCE0FF&}{\c&HFFFFE0&}N{\c&HFFFFE0&}{\c&HFFF0F5&}はね{\c&HFFF0F5&}{\c&HFFE4E1&}返せる{\c&HFFE4E1&}よね？
+Dialogue: 0,0:16:19.51,0:16:22.84,Default,,0,0,0,,{\c&HFFFFCC&}I'm{\c&HFFFFCC&} {\c&HFFCCCC&}sure{\c&HFFCCCC&} {\c&HFFCCFF&}you{\c&HFFCCFF&} {\c&HCCE5FF&}can{\c&HCCE5FF&} {\c&HFFD8B1&}\{\c&HFFD8B1&} {\c&HCCE0FF&}Nendure{\c&HCCE0FF&} {\c&HFFFFE0&}some{\c&HFFFFE0&} {\c&HFFF0F5&}adversity{\c&HFFF0F5&} {\c&HFFE4E1&}.{\c&HFFE4E1&}
+Dialogue: 0,0:16:22.94,0:16:24.91,Default,,0,0,0,,{\c&HFAFAD2&}You{\c&HFAFAD2&} {\c&HFFFACD&}can{\c&HFFFACD&} {\c&HFFEFD5&}do{\c&HFFEFD5&} {\c&HFFFFF0&}it{\c&HFFFFF0&} {\c&HFFF5EE&}.{\c&HFFF5EE&}
+Dialogue: 0,0:16:23.07,0:16:25.60,Default-ja,,0,0,0,,{\c&HFAFAD2&}ファイト{\c&HFAFAD2&}{\c&HFFFACD&}オー{\c&HFFFACD&}{\c&HFFEFD5&}です{\c&HFFEFD5&}{\c&HFFFFF0&}\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}（圭一）う～ん…
+Dialogue: 0,0:16:25.95,0:16:28.85,Default,,0,0,0,,{\c&HFAEBD7&}Come{\c&HFAEBD7&} {\c&HFFFAFA&}on{\c&HFFFAFA&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HFFFFFF&}Keiichi{\c&HFFFFFF&} {\c&HCCFFFF&}.{\c&HCCFFFF&} {\c&HCCFFCC&}Don't{\c&HCCFFCC&} {\c&HFFFFCC&}hide{\c&HFFFFCC&} it .
+Dialogue: 0,0:16:26.07,0:16:29.01,Default-ja,,0,0,0,,{\c&HFAEBD7&}ほら{\c&HFAEBD7&}{\c&HFFFAFA&}圭{\c&HFFFAFA&}{\c&HCCFFFF&}ちゃん{\c&HCCFFFF&}{\c&HFFFFFF&}隠さ{\c&HFFFFFF&}{\c&HCCFFFF&}ない{\c&HCCFFFF&}{\c&HCCFFCC&}隠さ{\c&HCCFFCC&}{\c&HFFFFCC&}ない{\c&HFFFFCC&}
+Dialogue: 0,0:16:29.92,0:16:33.41,Default,,0,0,0,,{\c&HFFCCCC&}This{\c&HFFCCCC&} {\c&HFFCCFF&}scratched{\c&HFFCCFF&} {\c&HCCE5FF&}one{\c&HCCE5FF&} {\c&HFFD8B1&}is{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}Nthe{\c&HFFFFE0&} {\c&HFFF0F5&}two{\c&HFFF0F5&} {\c&HFFE4E1&}of{\c&HFFE4E1&} {\c&HFAFAD2&}diamonds{\c&HFAFAD2&} {\c&HFFFACD&},{\c&HFFFACD&} {\c&HFFEFD5&}right{\c&HFFEFD5&} {\c&HFFFFF0&}?{\c&HFFFFF0&}
+Dialogue: 0,0:16:30.04,0:16:33.38,Default-ja,,0,0,0,,{\c&HFFCCCC&}（{\c&HFFCCCC&}{\c&HFFCCFF&}魅{\c&HFFCCFF&}{\c&HCCE5FF&}音{\c&HCCE5FF&}{\c&HFFD8B1&}）{\c&HFFD8B1&}{\c&HCCE0FF&}\{\c&HCCE0FF&}{\c&HFFFFE0&}N{\c&HFFFFE0&}{\c&HFFF0F5&}この{\c&HFFF0F5&}{\c&HFFE4E1&}傷{\c&HFFE4E1&}{\c&HFAFAD2&}が{\c&HFAFAD2&}{\c&HFFFACD&}確か{\c&HFFFACD&}{\c&HFFEFD5&}ダイヤ{\c&HFFEFD5&}{\c&HFFFFF0&}の{\c&HFFFFF0&}２だったよね
+Dialogue: 0,0:16:33.54,0:16:34.41,Default-ja,,0,0,0,,{\c&HFFF5EE&}あれ{\c&HFFF5EE&}{\c&HFAEBD7&}？{\c&HFAEBD7&}
+Dialogue: 0,0:16:33.89,0:16:34.85,Default,,0,0,0,,{\c&HFFF5EE&}Huh{\c&HFFF5EE&} {\c&HFAEBD7&}?{\c&HFAEBD7&}
+Dialogue: 0,0:16:34.88,0:16:39.08,Default-ja,,0,0,0,,{\c&HFFFAFA&}あっ{\c&HFFFAFA&}{\c&HCCFFFF&}魅{\c&HCCFFFF&}{\c&HFFFFFF&}ぃちゃんが{\c&HFFFFFF&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HCCFFCC&}N{\c&HCCFFCC&}{\c&HFFFFCC&}カード{\c&HFFFFCC&}{\c&HFFCCCC&}間違える{\c&HFFCCCC&}{\c&HFFCCFF&}なんて{\c&HFFCCFF&}{\c&HCCE5FF&}珍しい{\c&HCCE5FF&}{\c&HFFD8B1&}ね{\c&HFFD8B1&}
+Dialogue: 0,0:16:35.79,0:16:39.02,Default,,0,0,0,,{\c&HFFFAFA&}It's{\c&HFFFAFA&} {\c&HCCFFFF&}rare{\c&HCCFFFF&} {\c&HFFFFFF&}for{\c&HFFFFFF&} {\c&HCCFFFF&}you{\c&HCCFFFF&} {\c&HCCFFCC&}\{\c&HCCFFCC&} {\c&HFFFFCC&}Nto{\c&HFFFFCC&} {\c&HFFCCCC&}make{\c&HFFCCCC&} {\c&HFFCCFF&}a{\c&HFFCCFF&} {\c&HCCE5FF&}mistake{\c&HCCE5FF&} {\c&HFFD8B1&},{\c&HFFD8B1&} Mi - chan .
+Dialogue: 0,0:16:39.13,0:16:41.42,Default,,0,0,0,,{\c&HCCE0FF&}T{\c&HCCE0FF&} {\c&HFFFFE0&}-{\c&HFFFFE0&} {\c&HFFF0F5&}That's{\c&HFFF0F5&} not it . Kei - chan ...
+Dialogue: 0,0:16:39.18,0:16:40.62,Default-ja,,0,0,0,,{\c&HCCE0FF&}ち{\c&HCCE0FF&}{\c&HFFFFE0&}…{\c&HFFFFE0&}{\c&HFFF0F5&}違う{\c&HFFF0F5&}
+Dialogue: 0,0:16:40.92,0:16:43.32,Default-ja,,0,0,0,,{\c&HFFE4E1&}圭{\c&HFFE4E1&}{\c&HFAFAD2&}ちゃん{\c&HFAFAD2&}{\c&HFFFACD&}あんた{\c&HFFFACD&}まさか…
+Dialogue: 0,0:16:41.80,0:16:43.59,Default,,0,0,0,,{\c&HFFE4E1&}Did{\c&HFFE4E1&} {\c&HFAFAD2&}you{\c&HFAFAD2&} {\c&HFFFACD&}...{\c&HFFFACD&}
+Dialogue: 0,0:16:46.42,0:16:50.23,Default-ja,,0,0,0,,{\c&HFFEFD5&}ハハハハッ{\c&HFFEFD5&}{\c&HFFFFF0&}！\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}{\c&HFAEBD7&}引っ掛かっ{\c&HFAEBD7&}{\c&HFFFAFA&}た{\c&HFFFAFA&}{\c&HCCFFFF&}な{\c&HCCFFFF&}{\c&HFFFFFF&}園{\c&HFFFFFF&}崎魅音！
+Dialogue: 0,0:16:48.27,0:16:50.74,Default,,0,0,0,,{\c&HFFEFD5&}I{\c&HFFEFD5&} {\c&HFFFFF0&}got{\c&HFFFFF0&} {\c&HFFF5EE&}you{\c&HFFF5EE&} {\c&HFAEBD7&},{\c&HFAEBD7&} {\c&HFFFAFA&}Mion{\c&HFFFAFA&} {\c&HCCFFFF&}Sonozaki{\c&HCCFFFF&} {\c&HFFFFFF&}!{\c&HFFFFFF&}
+Dialogue: 0,0:16:50.84,0:16:54.14,Default,,0,0,0,,{\c&HCCFFFF&}You{\c&HCCFFFF&} {\c&HCCFFCC&}somehow{\c&HCCFFCC&} {\c&HFFFFCC&}forged{\c&HFFFFCC&} {\c&HFFCCCC&}\{\c&HFFCCCC&} {\c&HFFCCFF&}Nthe{\c&HFFCCFF&} {\c&HCCE5FF&}two{\c&HCCE5FF&} {\c&HFFD8B1&}of{\c&HFFD8B1&} {\c&HCCE0FF&}diamonds{\c&HCCE0FF&} {\c&HFFFFE0&}?{\c&HFFFFE0&}
+Dialogue: 0,0:16:50.93,0:16:53.43,Default-ja,,0,0,0,,{\c&HCCFFFF&}ダイヤ{\c&HCCFFFF&}{\c&HCCFFCC&}の{\c&HCCFFCC&}{\c&HFFFFCC&}２{\c&HFFFFCC&}{\c&HFFCCCC&}を{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}{\c&HFFD8B1&}偽装{\c&HFFD8B1&}{\c&HCCE0FF&}し{\c&HCCE0FF&}{\c&HFFFFE0&}た{\c&HFFFFE0&}というんですの？
+Dialogue: 0,0:16:53.53,0:16:56.63,Default-ja,,0,0,0,,{\c&HFFF0F5&}あ{\c&HFFF0F5&}{\c&HFFE4E1&}…{\c&HFFE4E1&}{\c&HFAFAD2&}味{\c&HFAFAD2&}{\c&HFFFACD&}な{\c&HFFFACD&}{\c&HFFEFD5&}マネ{\c&HFFEFD5&}{\c&HFFFFF0&}を{\c&HFFFFF0&}\Nするでございますわね
+Dialogue: 0,0:16:54.24,0:16:56.73,Default,,0,0,0,,{\c&HFFF0F5&}You{\c&HFFF0F5&} {\c&HFFE4E1&}made{\c&HFFE4E1&} {\c&HFAFAD2&}a{\c&HFAFAD2&} {\c&HFFFACD&}witty{\c&HFFFACD&} {\c&HFFEFD5&}move{\c&HFFEFD5&} {\c&HFFFFF0&}.{\c&HFFFFF0&}
+Dialogue: 0,0:16:56.84,0:17:00.14,Default,,0,0,0,,{\c&HFFF5EE&}You{\c&HFFF5EE&} {\c&HFAEBD7&}got{\c&HFAEBD7&} {\c&HFFFAFA&}them{\c&HFFFAFA&} {\c&HCCFFFF&}back{\c&HCCFFFF&} {\c&HFFFFFF&},{\c&HFFFFFF&} {\c&HCCFFFF&}Keiichi{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:16:56.93,0:17:00.24,Default-ja,,0,0,0,,{\c&HFFF5EE&}圭一{\c&HFFF5EE&}{\c&HFAEBD7&}一矢{\c&HFAEBD7&}{\c&HFFFAFA&}を{\c&HFFFAFA&}{\c&HCCFFFF&}報い{\c&HCCFFFF&}{\c&HFFFFFF&}まし{\c&HFFFFFF&}{\c&HCCFFFF&}た{\c&HCCFFFF&}{\c&HCCFFCC&}です{\c&HCCFFCC&}\N（圭一）ヘヘッ！
+Dialogue: 0,0:17:00.75,0:17:04.65,Default,,0,0,0,,{\c&HFFFFCC&}You{\c&HFFFFCC&} {\c&HFFCCCC&}did{\c&HFFCCCC&} {\c&HFFCCFF&}it{\c&HFFCCFF&} {\c&HCCE5FF&}!{\c&HCCE5FF&} {\c&HFFD8B1&}It{\c&HFFD8B1&} {\c&HCCE0FF&}was{\c&HCCE0FF&} {\c&HFFFFE0&}\{\c&HFFFFE0&} {\c&HFFF0F5&}Na{\c&HFFF0F5&} {\c&HFFE4E1&}close{\c&HFFE4E1&} {\c&HFAFAD2&}game{\c&HFAFAD2&} {\c&HFFFACD&}!{\c&HFFFACD&} {\c&HFFEFD5&}It{\c&HFFEFD5&} {\c&HFFFFF0&}was{\c&HFFFFF0&} {\c&HFFF5EE&}!{\c&HFFF5EE&}
+Dialogue: 0,0:17:00.87,0:17:04.57,Default-ja,,0,0,0,,{\c&HFFFFCC&}やっ{\c&HFFFFCC&}{\c&HFFCCCC&}た{\c&HFFCCCC&}{\c&HFFCCFF&}ね{\c&HFFCCFF&}{\c&HCCE5FF&}圭一{\c&HCCE5FF&}{\c&HFFD8B1&}君{\c&HFFD8B1&}{\c&HCCE0FF&}\{\c&HCCE0FF&}{\c&HFFFFE0&}N{\c&HFFFFE0&}{\c&HFFF0F5&}大{\c&HFFF0F5&}{\c&HFFE4E1&}善戦{\c&HFFE4E1&}{\c&HFAFAD2&}だ{\c&HFAFAD2&}{\c&HFFFACD&}よ{\c&HFFFACD&}{\c&HFFEFD5&}！{\c&HFFEFD5&}{\c&HFFFFF0&}だ{\c&HFFFFF0&}{\c&HFFF5EE&}よ{\c&HFFF5EE&}！
+Dialogue: 0,0:17:04.75,0:17:08.09,Default,,0,0,0,,{\c&HFAEBD7&}I{\c&HFAEBD7&} {\c&HFFFAFA&}knew{\c&HFFFAFA&} {\c&HCCFFFF&}you{\c&HCCFFFF&} {\c&HFFFFFF&}could{\c&HFFFFFF&} {\c&HCCFFFF&}do{\c&HCCFFFF&} {\c&HCCFFCC&}it{\c&HCCFFCC&} {\c&HFFFFCC&}.{\c&HFFFFCC&}
+Dialogue: 0,0:17:04.88,0:17:07.98,Default-ja,,0,0,0,,{\c&HFAEBD7&}さすが{\c&HFAEBD7&}{\c&HFFFAFA&}\{\c&HFFFAFA&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HFFFFFF&}あたし{\c&HFFFFFF&}{\c&HCCFFFF&}が{\c&HCCFFFF&}{\c&HCCFFCC&}見込ん{\c&HCCFFCC&}{\c&HFFFFCC&}だ{\c&HFFFFCC&}だけのことはある
+Dialogue: 0,0:17:08.19,0:17:11.65,Default,,0,0,0,,{\c&HFFCCCC&}I{\c&HFFCCCC&} {\c&HFFCCFF&}never{\c&HFFCCFF&} {\c&HCCE5FF&}expected{\c&HCCE5FF&} {\c&HFFD8B1&}you{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}Nto{\c&HFFFFE0&} {\c&HFFF0F5&}think{\c&HFFF0F5&} {\c&HFFE4E1&}of{\c&HFFE4E1&} {\c&HFAFAD2&}something{\c&HFAFAD2&} {\c&HFFFACD&}like{\c&HFFFACD&} {\c&HFFEFD5&}this{\c&HFFEFD5&} {\c&HFFFFF0&}.{\c&HFFFFF0&}
+Dialogue: 0,0:17:08.21,0:17:11.65,Default-ja,,0,0,0,,{\c&HFFCCCC&}こんな{\c&HFFCCCC&}{\c&HFFCCFF&}手{\c&HFFCCFF&}{\c&HCCE5FF&}を{\c&HCCE5FF&}{\c&HFFD8B1&}思いつく{\c&HFFD8B1&}{\c&HCCE0FF&}と{\c&HCCE0FF&}{\c&HFFFFE0&}は{\c&HFFFFE0&}{\c&HFFF0F5&}\{\c&HFFF0F5&}{\c&HFFE4E1&}N{\c&HFFE4E1&}{\c&HFAFAD2&}圭{\c&HFAFAD2&}{\c&HFFFACD&}ちゃん{\c&HFFFACD&}{\c&HFFEFD5&}さすが{\c&HFFEFD5&}{\c&HFFFFF0&}だ{\c&HFFFFF0&}よ
+Dialogue: 0,0:17:11.98,0:17:13.15,Default-ja,,0,0,0,,{\c&HFFF5EE&}ウフフッ{\c&HFFF5EE&}{\c&HFAEBD7&}…{\c&HFAEBD7&}
+Dialogue: 0,0:17:13.23,0:17:16.39,Default,,0,0,0,,{\c&HFFF5EE&}Except{\c&HFFF5EE&} {\c&HFAEBD7&}you're{\c&HFAEBD7&} too late .
+Dialogue: 0,0:17:13.25,0:17:16.45,Default-ja,,0,0,0,,{\c&HFFFAFA&}…{\c&HFFFAFA&}{\c&HCCFFFF&}と{\c&HCCFFFF&}{\c&HFFFFFF&}は{\c&HFFFFFF&}{\c&HCCFFFF&}いっ{\c&HCCFFFF&}{\c&HCCFFCC&}て{\c&HCCFFCC&}{\c&HFFFFCC&}も{\c&HFFFFCC&}{\c&HFFCCCC&}\{\c&HFFCCCC&}{\c&HFFCCFF&}N{\c&HFFCCFF&}{\c&HCCE5FF&}ちょっと{\c&HCCE5FF&}手遅れだったようですわね
+Dialogue: 0,0:17:16.93,0:17:19.63,Default,,0,0,0,,{\c&HFFFAFA&}I'm{\c&HFFFAFA&} {\c&HCCFFFF&}pretty{\c&HCCFFFF&} {\c&HFFFFFF&}much{\c&HFFFFFF&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HCCFFCC&}Nset{\c&HCCFFCC&} {\c&HFFFFCC&}in{\c&HFFFFCC&} {\c&HFFCCCC&}last{\c&HFFCCCC&} {\c&HFFCCFF&}place{\c&HFFCCFF&} {\c&HCCE5FF&}...{\c&HCCE5FF&}
 Dialogue: 0,0:17:17.02,0:17:19.46,Default-ja,,0,0,0,,まあ ビリは確定だけどさ
-Dialogue: 0,0:17:19.66,0:17:23.49,Default-ja,,0,0,0,,最後に\N魅音から１本取れたから大満足かな
-Dialogue: 0,0:17:19.73,0:17:23.67,Default,,0,0,0,,...but I was able to get\Nback at Mion, so I'm satisfied.
-Dialogue: 0,0:17:25.50,0:17:29.23,Default-ja,,0,0,0,,そんじゃ\Nビリの圭ちゃんには罰ゲームだねえ
-Dialogue: 0,0:17:25.54,0:17:29.41,Default,,0,0,0,,Then let's do the punishment\Ngame since you're last.
-Dialogue: 0,0:17:29.47,0:17:33.97,Default-ja,,0,0,0,,今日は部活の初日だし\Nソフトなのから いこうかなぁ？
-Dialogue: 0,0:17:29.51,0:17:33.91,Default,,0,0,0,,Since it's your first day in\Nthe club, maybe I'll go easy.
-Dialogue: 0,0:17:34.05,0:17:38.45,Default,,0,0,0,,I wouldn't want you to stop\Ncoming to school all of a sudden.
-Dialogue: 0,0:17:34.20,0:17:38.07,Default-ja,,0,0,0,,（魅音）いきなり\N登校拒否になられても困るしねえ
-Dialogue: 0,0:17:38.28,0:17:40.38,Default-ja,,0,0,0,,ウフフフッ…\N（圭一）あっ！ な… なに？
-Dialogue: 0,0:17:39.95,0:17:40.92,Default,,0,0,0,,What?
-Dialogue: 0,0:17:41.68,0:17:43.31,Default-ja,,0,0,0,,ほ～れ…
-Dialogue: 0,0:17:42.06,0:17:43.92,Default,,0,0,0,,Hey...
-Dialogue: 0,0:17:44.51,0:17:47.45,Default-ja,,0,0,0,,ほ～れ！\N（圭一）アアッ…
-Dialogue: 0,0:17:44.66,0:17:46.96,Default,,0,0,0,,Hey...
-Dialogue: 0,0:17:46.96,0:17:51.36,Default,,0,0,0,,S-Stop!
-Dialogue: 0,0:17:47.55,0:17:50.55,Default-ja,,0,0,0,,や… やめろー！
-Dialogue: 0,0:17:55.56,0:17:57.26,Default-ja,,0,0,0,,ケンタくん人形？
-Dialogue: 0,0:17:55.60,0:17:57.23,Default,,0,0,0,,A Kenta doll?
-Dialogue: 0,0:17:57.34,0:17:58.90,Default,,0,0,0,,I see.
-Dialogue: 0,0:17:57.36,0:18:01.56,Default-ja,,0,0,0,,なるほど！ それで レナのヤツ\N飛んで帰っちゃったのか
+Dialogue: 0,0:17:19.66,0:17:23.49,Default-ja,,0,0,0,,{\c&HFFD8B1&}最後{\c&HFFD8B1&}{\c&HCCE0FF&}に{\c&HCCE0FF&}{\c&HFFFFE0&}\{\c&HFFFFE0&}{\c&HFFF0F5&}N{\c&HFFF0F5&}{\c&HFFE4E1&}魅{\c&HFFE4E1&}{\c&HFAFAD2&}音{\c&HFAFAD2&}{\c&HFFFACD&}から{\c&HFFFACD&}{\c&HFFEFD5&}１{\c&HFFEFD5&}{\c&HFFFFF0&}本{\c&HFFFFF0&}{\c&HFFF5EE&}取れ{\c&HFFF5EE&}{\c&HFAEBD7&}た{\c&HFAEBD7&}{\c&HFFFAFA&}から{\c&HFFFAFA&}{\c&HCCFFFF&}大{\c&HCCFFFF&}{\c&HFFFFFF&}満足{\c&HFFFFFF&}{\c&HCCFFFF&}か{\c&HCCFFFF&}{\c&HCCFFCC&}な{\c&HCCFFCC&}
+Dialogue: 0,0:17:19.73,0:17:23.67,Default,,0,0,0,,{\c&HFFD8B1&}...{\c&HFFD8B1&} {\c&HCCE0FF&}but{\c&HCCE0FF&} {\c&HFFFFE0&}I{\c&HFFFFE0&} {\c&HFFF0F5&}was{\c&HFFF0F5&} {\c&HFFE4E1&}able{\c&HFFE4E1&} {\c&HFAFAD2&}to{\c&HFAFAD2&} {\c&HFFFACD&}get{\c&HFFFACD&} {\c&HFFEFD5&}\{\c&HFFEFD5&} {\c&HFFFFF0&}Nback{\c&HFFFFF0&} {\c&HFFF5EE&}at{\c&HFFF5EE&} {\c&HFAEBD7&}Mion{\c&HFAEBD7&} {\c&HFFFAFA&},{\c&HFFFAFA&} {\c&HCCFFFF&}so{\c&HCCFFFF&} {\c&HFFFFFF&}I'm{\c&HFFFFFF&} {\c&HCCFFFF&}satisfied{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:17:25.50,0:17:29.23,Default-ja,,0,0,0,,{\c&HFFFFCC&}そん{\c&HFFFFCC&}{\c&HFFCCCC&}じゃ{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}{\c&HFFD8B1&}ビリ{\c&HFFD8B1&}{\c&HCCE0FF&}の{\c&HCCE0FF&}{\c&HFFFFE0&}圭{\c&HFFFFE0&}{\c&HFFF0F5&}ちゃん{\c&HFFF0F5&}{\c&HFFE4E1&}に{\c&HFFE4E1&}{\c&HFAFAD2&}は{\c&HFAFAD2&}{\c&HFFFACD&}罰{\c&HFFFACD&}ゲームだねえ
+Dialogue: 0,0:17:25.54,0:17:29.41,Default,,0,0,0,,{\c&HFFFFCC&}Then{\c&HFFFFCC&} {\c&HFFCCCC&}let's{\c&HFFCCCC&} {\c&HFFCCFF&}do{\c&HFFCCFF&} {\c&HCCE5FF&}the{\c&HCCE5FF&} {\c&HFFD8B1&}punishment{\c&HFFD8B1&} {\c&HCCE0FF&}\{\c&HCCE0FF&} {\c&HFFFFE0&}Ngame{\c&HFFFFE0&} {\c&HFFF0F5&}since{\c&HFFF0F5&} {\c&HFFE4E1&}you're{\c&HFFE4E1&} {\c&HFAFAD2&}last{\c&HFAFAD2&} {\c&HFFFACD&}.{\c&HFFFACD&}
+Dialogue: 0,0:17:29.47,0:17:33.97,Default-ja,,0,0,0,,{\c&HFFEFD5&}今日{\c&HFFEFD5&}{\c&HFFFFF0&}は{\c&HFFFFF0&}{\c&HFFF5EE&}部活{\c&HFFF5EE&}{\c&HFAEBD7&}の{\c&HFAEBD7&}{\c&HFFFAFA&}初日{\c&HFFFAFA&}{\c&HCCFFFF&}だ{\c&HCCFFFF&}{\c&HFFFFFF&}し{\c&HFFFFFF&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HCCFFCC&}N{\c&HCCFFCC&}{\c&HFFFFCC&}ソフト{\c&HFFFFCC&}{\c&HFFCCCC&}な{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}{\c&HCCE5FF&}から{\c&HCCE5FF&}{\c&HFFD8B1&}いこ{\c&HFFD8B1&}{\c&HCCE0FF&}う{\c&HCCE0FF&}かなぁ？
+Dialogue: 0,0:17:29.51,0:17:33.91,Default,,0,0,0,,{\c&HFFEFD5&}Since{\c&HFFEFD5&} {\c&HFFFFF0&}it's{\c&HFFFFF0&} {\c&HFFF5EE&}your{\c&HFFF5EE&} {\c&HFAEBD7&}first{\c&HFAEBD7&} {\c&HFFFAFA&}day{\c&HFFFAFA&} {\c&HCCFFFF&}in{\c&HCCFFFF&} {\c&HFFFFFF&}\{\c&HFFFFFF&} {\c&HCCFFFF&}Nthe{\c&HCCFFFF&} {\c&HCCFFCC&}club{\c&HCCFFCC&} {\c&HFFFFCC&},{\c&HFFFFCC&} {\c&HFFCCCC&}maybe{\c&HFFCCCC&} {\c&HFFCCFF&}I'll{\c&HFFCCFF&} {\c&HCCE5FF&}go{\c&HCCE5FF&} {\c&HFFD8B1&}easy{\c&HFFD8B1&} {\c&HCCE0FF&}.{\c&HCCE0FF&}
+Dialogue: 0,0:17:34.05,0:17:38.45,Default,,0,0,0,,{\c&HFFFFE0&}I{\c&HFFFFE0&} {\c&HFFF0F5&}wouldn't{\c&HFFF0F5&} {\c&HFFE4E1&}want{\c&HFFE4E1&} {\c&HFAFAD2&}you{\c&HFAFAD2&} {\c&HFFFACD&}to{\c&HFFFACD&} {\c&HFFEFD5&}stop{\c&HFFEFD5&} {\c&HFFFFF0&}\{\c&HFFFFF0&} {\c&HFFF5EE&}Ncoming{\c&HFFF5EE&} {\c&HFAEBD7&}to{\c&HFAEBD7&} {\c&HFFFAFA&}school{\c&HFFFAFA&} {\c&HCCFFFF&}all{\c&HCCFFFF&} {\c&HFFFFFF&}of{\c&HFFFFFF&} {\c&HCCFFFF&}a{\c&HCCFFFF&} {\c&HCCFFCC&}sudden{\c&HCCFFCC&} {\c&HFFFFCC&}.{\c&HFFFFCC&}
+Dialogue: 0,0:17:34.20,0:17:38.07,Default-ja,,0,0,0,,{\c&HFFFFE0&}（{\c&HFFFFE0&}{\c&HFFF0F5&}魅{\c&HFFF0F5&}{\c&HFFE4E1&}音{\c&HFFE4E1&}{\c&HFAFAD2&}）{\c&HFAFAD2&}{\c&HFFFACD&}いきなり{\c&HFFFACD&}{\c&HFFEFD5&}\{\c&HFFEFD5&}{\c&HFFFFF0&}N{\c&HFFFFF0&}{\c&HFFF5EE&}登校{\c&HFFF5EE&}{\c&HFAEBD7&}拒否{\c&HFAEBD7&}{\c&HFFFAFA&}に{\c&HFFFAFA&}{\c&HCCFFFF&}なら{\c&HCCFFFF&}{\c&HFFFFFF&}れ{\c&HFFFFFF&}{\c&HCCFFFF&}て{\c&HCCFFFF&}{\c&HCCFFCC&}も{\c&HCCFFCC&}{\c&HFFFFCC&}困る{\c&HFFFFCC&}しねえ
+Dialogue: 0,0:17:38.28,0:17:40.38,Default-ja,,0,0,0,,{\c&HFFCCCC&}ウフフフッ{\c&HFFCCCC&}{\c&HFFCCFF&}…{\c&HFFCCFF&}\N（圭一）あっ！な…なに？
+Dialogue: 0,0:17:39.95,0:17:40.92,Default,,0,0,0,,{\c&HFFCCCC&}What{\c&HFFCCCC&} {\c&HFFCCFF&}?{\c&HFFCCFF&}
+Dialogue: 0,0:17:41.68,0:17:43.31,Default-ja,,0,0,0,,{\c&HCCE5FF&}ほ{\c&HCCE5FF&}{\c&HFFD8B1&}～{\c&HFFD8B1&}れ…
+Dialogue: 0,0:17:42.06,0:17:43.92,Default,,0,0,0,,{\c&HCCE5FF&}Hey{\c&HCCE5FF&} {\c&HFFD8B1&}...{\c&HFFD8B1&}
+Dialogue: 0,0:17:44.51,0:17:47.45,Default-ja,,0,0,0,,{\c&HCCE0FF&}ほ{\c&HCCE0FF&}{\c&HFFFFE0&}～{\c&HFFFFE0&}れ！\N（圭一）アアッ…
+Dialogue: 0,0:17:44.66,0:17:46.96,Default,,0,0,0,,{\c&HCCE0FF&}Hey{\c&HCCE0FF&} {\c&HFFFFE0&}...{\c&HFFFFE0&}
+Dialogue: 0,0:17:46.96,0:17:51.36,Default,,0,0,0,,{\c&HFFF0F5&}S{\c&HFFF0F5&} {\c&HFFE4E1&}-{\c&HFFE4E1&} {\c&HFAFAD2&}Stop{\c&HFAFAD2&} {\c&HFFFACD&}!{\c&HFFFACD&}
+Dialogue: 0,0:17:47.55,0:17:50.55,Default-ja,,0,0,0,,{\c&HFFF0F5&}や{\c&HFFF0F5&}{\c&HFFE4E1&}…{\c&HFFE4E1&}{\c&HFAFAD2&}やめろ{\c&HFAFAD2&}{\c&HFFFACD&}ー{\c&HFFFACD&}！
+Dialogue: 0,0:17:55.56,0:17:57.26,Default-ja,,0,0,0,,{\c&HFFEFD5&}ケンタ{\c&HFFEFD5&}{\c&HFFFFF0&}くん{\c&HFFFFF0&}{\c&HFFF5EE&}人形{\c&HFFF5EE&}{\c&HFAEBD7&}？{\c&HFAEBD7&}
+Dialogue: 0,0:17:55.60,0:17:57.23,Default,,0,0,0,,{\c&HFFEFD5&}A{\c&HFFEFD5&} {\c&HFFFFF0&}Kenta{\c&HFFFFF0&} {\c&HFFF5EE&}doll{\c&HFFF5EE&} {\c&HFAEBD7&}?{\c&HFAEBD7&}
+Dialogue: 0,0:17:57.34,0:17:58.90,Default,,0,0,0,,{\c&HFFFAFA&}I{\c&HFFFAFA&} {\c&HCCFFFF&}see{\c&HCCFFFF&} {\c&HFFFFFF&}.{\c&HFFFFFF&}
+Dialogue: 0,0:17:57.36,0:18:01.56,Default-ja,,0,0,0,,{\c&HFFFAFA&}なるほど{\c&HFFFAFA&}{\c&HCCFFFF&}！{\c&HCCFFFF&}{\c&HFFFFFF&}それで{\c&HFFFFFF&}レナのヤツ\N飛んで帰っちゃったのか
 Dialogue: 0,0:17:59.01,0:18:01.53,Default,,0,0,0,,That's why Rena took off so fast.
-Dialogue: 0,0:18:02.08,0:18:05.77,Default,,0,0,0,,Thinking that thing is cute...\NShe's pretty weird.
-Dialogue: 0,0:18:02.13,0:18:05.97,Default-ja,,0,0,0,,あんなのが かわいいなんて\N変わってるよな レナも
-Dialogue: 0,0:18:06.08,0:18:10.92,Default,,0,0,0,,Weird hobbies too, but once\Nshe finds something cute...
-Dialogue: 0,0:18:06.17,0:18:07.67,Default-ja,,0,0,0,,（魅音）趣味も変わってるけど
-Dialogue: 0,0:18:07.97,0:18:11.01,Default-ja,,0,0,0,,レナのヤツ いったん\N“かわいいモード”に入っちゃうと
-Dialogue: 0,0:18:11.02,0:18:14.39,Default,,0,0,0,,...she becomes\Noblivious to everything else.
+Dialogue: 0,0:18:02.08,0:18:05.77,Default,,0,0,0,,{\c&HCCFFFF&}Thinking{\c&HCCFFFF&} {\c&HCCFFCC&}that{\c&HCCFFCC&} {\c&HFFFFCC&}thing{\c&HFFFFCC&} {\c&HFFCCCC&}is{\c&HFFCCCC&} {\c&HFFCCFF&}cute{\c&HFFCCFF&} {\c&HCCE5FF&}...\{\c&HCCE5FF&} {\c&HFFD8B1&}NShe's{\c&HFFD8B1&} {\c&HCCE0FF&}pretty{\c&HCCE0FF&} {\c&HFFFFE0&}weird{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:18:02.13,0:18:05.97,Default-ja,,0,0,0,,{\c&HCCFFFF&}あんな{\c&HCCFFFF&}{\c&HCCFFCC&}の{\c&HCCFFCC&}{\c&HFFFFCC&}が{\c&HFFFFCC&}{\c&HFFCCCC&}かわいい{\c&HFFCCCC&}{\c&HFFCCFF&}なんて{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}変わっ{\c&HCCE0FF&}{\c&HFFFFE0&}てる{\c&HFFFFE0&}{\c&HFFF0F5&}よ{\c&HFFF0F5&}なレナも
+Dialogue: 0,0:18:06.08,0:18:10.92,Default,,0,0,0,,{\c&HFFE4E1&}Weird{\c&HFFE4E1&} {\c&HFAFAD2&}hobbies{\c&HFAFAD2&} {\c&HFFFACD&}too{\c&HFFFACD&} {\c&HFFEFD5&},{\c&HFFEFD5&} {\c&HFFFFF0&}but{\c&HFFFFF0&} {\c&HFFF5EE&}once{\c&HFFF5EE&} {\c&HFAEBD7&}\{\c&HFAEBD7&} {\c&HFFFAFA&}Nshe{\c&HFFFAFA&} {\c&HCCFFFF&}finds{\c&HCCFFFF&} something cute ...
+Dialogue: 0,0:18:06.17,0:18:07.67,Default-ja,,0,0,0,,{\c&HFFE4E1&}（{\c&HFFE4E1&}{\c&HFAFAD2&}魅{\c&HFAFAD2&}{\c&HFFFACD&}音{\c&HFFFACD&}{\c&HFFEFD5&}）{\c&HFFEFD5&}{\c&HFFFFF0&}趣味{\c&HFFFFF0&}{\c&HFFF5EE&}も{\c&HFFF5EE&}{\c&HFAEBD7&}変わっ{\c&HFAEBD7&}{\c&HFFFAFA&}てる{\c&HFFFAFA&}{\c&HCCFFFF&}けど{\c&HCCFFFF&}
+Dialogue: 0,0:18:07.97,0:18:11.01,Default-ja,,0,0,0,,{\c&HFFFFFF&}レナ{\c&HFFFFFF&}{\c&HCCFFFF&}の{\c&HCCFFFF&}{\c&HCCFFCC&}ヤツ{\c&HCCFFCC&}{\c&HFFFFCC&}いったん{\c&HFFFFCC&}{\c&HFFCCCC&}\{\c&HFFCCCC&}{\c&HFFCCFF&}N{\c&HFFCCFF&}{\c&HCCE5FF&}“{\c&HCCE5FF&}{\c&HFFD8B1&}かわいい{\c&HFFD8B1&}{\c&HCCE0FF&}モード{\c&HCCE0FF&}”に入っちゃうと
+Dialogue: 0,0:18:11.02,0:18:14.39,Default,,0,0,0,,{\c&HFFFFFF&}...{\c&HFFFFFF&} {\c&HCCFFFF&}she{\c&HCCFFFF&} {\c&HCCFFCC&}becomes{\c&HCCFFCC&} {\c&HFFFFCC&}\{\c&HFFFFCC&} {\c&HFFCCCC&}Noblivious{\c&HFFCCCC&} {\c&HFFCCFF&}to{\c&HFFCCFF&} {\c&HCCE5FF&}everything{\c&HCCE5FF&} {\c&HFFD8B1&}else{\c&HFFD8B1&} {\c&HCCE0FF&}.{\c&HCCE0FF&}
 Dialogue: 0,0:18:11.11,0:18:13.48,Default-ja,,0,0,0,,後先 見えなくなっちゃうからね
-Dialogue: 0,0:18:14.44,0:18:18.21,Default-ja,,0,0,0,,（圭一）\Nあそこさ… ダムの工事現場
-Dialogue: 0,0:18:14.49,0:18:18.82,Default,,0,0,0,,About that place...\NThe dam construction site...
-Dialogue: 0,0:18:18.93,0:18:22.23,Default,,0,0,0,,Something happened\Nthere in the past, right?
-Dialogue: 0,0:18:19.02,0:18:21.58,Default-ja,,0,0,0,,何かあったんだろう？ 昔
-Dialogue: 0,0:18:22.33,0:18:23.46,Default,,0,0,0,,Yeah.
-Dialogue: 0,0:18:22.35,0:18:25.12,Default-ja,,0,0,0,,あったよ\N突然“ダム作る”って―
-Dialogue: 0,0:18:23.56,0:18:28.09,Default,,0,0,0,,Government officials suddenly\Ncame to evict us and build a dam.
-Dialogue: 0,0:18:25.22,0:18:28.12,Default-ja,,0,0,0,,役人どもが一方的に\N立ち退きを迫ってきて…
-Dialogue: 0,0:18:28.20,0:18:29.69,Default,,0,0,0,,Evict you?
-Dialogue: 0,0:18:28.26,0:18:29.66,Default-ja,,0,0,0,,（圭一）一方的に？
-Dialogue: 0,0:18:30.29,0:18:34.10,Default-ja,,0,0,0,,だから闘ったんだよ 村のみんなで
-Dialogue: 0,0:18:30.30,0:18:34.33,Default,,0,0,0,,That's why we fought.\NEveryone in the village.
-Dialogue: 0,0:18:34.43,0:18:38.70,Default-ja,,0,0,0,,闘わなければ 今ごろ\N村はダムの底に沈んでいたんだ
-Dialogue: 0,0:18:34.44,0:18:38.67,Default,,0,0,0,,If we hadn't, this village\Nwould've been underwater now.
-Dialogue: 0,0:18:39.57,0:18:43.14,Default-ja,,0,0,0,,（圭一）\Nよく勝てたな　相手は国だろう？
-Dialogue: 0,0:18:39.68,0:18:43.81,Default,,0,0,0,,I'm impressed you won.\NIt was against the government.
-Dialogue: 0,0:18:43.92,0:18:48.55,Default,,0,0,0,,The village's leader and powerful\Npeople petitioned together.
-Dialogue: 0,0:18:44.01,0:18:48.21,Default-ja,,0,0,0,,（魅音）村長や村の有力者たちがね\N方々に陳情した
-Dialogue: 0,0:18:48.61,0:18:52.42,Default-ja,,0,0,0,,東京にも行ったし\Nいろんな政治家に根回しもした
-Dialogue: 0,0:18:48.66,0:18:53.09,Default,,0,0,0,,They went to Tokyo and\Nnegotiated with the politicians.
-Dialogue: 0,0:18:53.19,0:18:56.75,Default,,0,0,0,,While doing all that,\Nthe plans got withdrawn.
-Dialogue: 0,0:18:53.25,0:18:56.22,Default-ja,,0,0,0,,そうしているうちに\N計画は撤回されたんだよ
-Dialogue: 0,0:18:56.86,0:18:59.33,Default,,0,0,0,,It was our perfect victory.
-Dialogue: 0,0:18:56.99,0:19:00.09,Default-ja,,0,0,0,,あたしたちの完全勝利だった\Nハハハハッ…
-Dialogue: 0,0:19:01.19,0:19:05.60,Default-ja,,0,0,0,,ふ～ん… 暴力沙汰とかには\Nならなかったのか？
-Dialogue: 0,0:19:02.74,0:19:06.04,Default,,0,0,0,,Were there any violent\Ncrimes because of it?
-Dialogue: 0,0:19:06.14,0:19:09.01,Default,,0,0,0,,Like assault or murder...
-Dialogue: 0,0:19:06.16,0:19:07.36,Default-ja,,0,0,0,,傷害事件とか…
+Dialogue: 0,0:18:14.44,0:18:18.21,Default-ja,,0,0,0,,{\c&HFFFFE0&}（{\c&HFFFFE0&}{\c&HFFF0F5&}圭一{\c&HFFF0F5&}{\c&HFFE4E1&}）{\c&HFFE4E1&}{\c&HFAFAD2&}\{\c&HFAFAD2&}{\c&HFFFACD&}N{\c&HFFFACD&}{\c&HFFEFD5&}あそこ{\c&HFFEFD5&}{\c&HFFFFF0&}さ{\c&HFFFFF0&}{\c&HFFF5EE&}…{\c&HFFF5EE&}{\c&HFAEBD7&}ダム{\c&HFAEBD7&}の工事現場
+Dialogue: 0,0:18:14.49,0:18:18.82,Default,,0,0,0,,{\c&HFFFFE0&}About{\c&HFFFFE0&} {\c&HFFF0F5&}that{\c&HFFF0F5&} {\c&HFFE4E1&}place{\c&HFFE4E1&} {\c&HFAFAD2&}...\{\c&HFAFAD2&} {\c&HFFFACD&}NThe{\c&HFFFACD&} {\c&HFFEFD5&}dam{\c&HFFEFD5&} {\c&HFFFFF0&}construction{\c&HFFFFF0&} {\c&HFFF5EE&}site{\c&HFFF5EE&} {\c&HFAEBD7&}...{\c&HFAEBD7&}
+Dialogue: 0,0:18:18.93,0:18:22.23,Default,,0,0,0,,{\c&HFFFAFA&}Something{\c&HFFFAFA&} {\c&HCCFFFF&}happened{\c&HCCFFFF&} {\c&HFFFFFF&}\{\c&HFFFFFF&} {\c&HCCFFFF&}Nthere{\c&HCCFFFF&} {\c&HCCFFCC&}in{\c&HCCFFCC&} {\c&HFFFFCC&}the{\c&HFFFFCC&} {\c&HFFCCCC&}past{\c&HFFCCCC&} {\c&HFFCCFF&},{\c&HFFCCFF&} {\c&HCCE5FF&}right{\c&HCCE5FF&} ?
+Dialogue: 0,0:18:19.02,0:18:21.58,Default-ja,,0,0,0,,{\c&HFFFAFA&}何{\c&HFFFAFA&}{\c&HCCFFFF&}か{\c&HCCFFFF&}{\c&HFFFFFF&}あっ{\c&HFFFFFF&}{\c&HCCFFFF&}た{\c&HCCFFFF&}{\c&HCCFFCC&}ん{\c&HCCFFCC&}{\c&HFFFFCC&}だろ{\c&HFFFFCC&}{\c&HFFCCCC&}う{\c&HFFCCCC&}{\c&HFFCCFF&}？{\c&HFFCCFF&}{\c&HCCE5FF&}昔{\c&HCCE5FF&}
+Dialogue: 0,0:18:22.33,0:18:23.46,Default,,0,0,0,,{\c&HFFD8B1&}Yeah{\c&HFFD8B1&} {\c&HCCE0FF&}.{\c&HCCE0FF&}
+Dialogue: 0,0:18:22.35,0:18:25.12,Default-ja,,0,0,0,,{\c&HFFD8B1&}あっ{\c&HFFD8B1&}{\c&HCCE0FF&}た{\c&HCCE0FF&}よ\N突然“ダム作る”って―
+Dialogue: 0,0:18:23.56,0:18:28.09,Default,,0,0,0,,{\c&HFFFFE0&}Government{\c&HFFFFE0&} {\c&HFFF0F5&}officials{\c&HFFF0F5&} {\c&HFFE4E1&}suddenly{\c&HFFE4E1&} {\c&HFAFAD2&}\{\c&HFAFAD2&} {\c&HFFFACD&}Ncame{\c&HFFFACD&} {\c&HFFEFD5&}to{\c&HFFEFD5&} {\c&HFFFFF0&}evict{\c&HFFFFF0&} {\c&HFFF5EE&}us{\c&HFFF5EE&} {\c&HFAEBD7&}and{\c&HFAEBD7&} {\c&HFFFAFA&}build{\c&HFFFAFA&} {\c&HCCFFFF&}a{\c&HCCFFFF&} {\c&HFFFFFF&}dam{\c&HFFFFFF&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
+Dialogue: 0,0:18:25.22,0:18:28.12,Default-ja,,0,0,0,,{\c&HFFFFE0&}役人{\c&HFFFFE0&}{\c&HFFF0F5&}ども{\c&HFFF0F5&}{\c&HFFE4E1&}が{\c&HFFE4E1&}{\c&HFAFAD2&}一方{\c&HFAFAD2&}{\c&HFFFACD&}的{\c&HFFFACD&}{\c&HFFEFD5&}に{\c&HFFEFD5&}{\c&HFFFFF0&}\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}{\c&HFAEBD7&}立ち退き{\c&HFAEBD7&}{\c&HFFFAFA&}を{\c&HFFFAFA&}{\c&HCCFFFF&}迫っ{\c&HCCFFFF&}{\c&HFFFFFF&}て{\c&HFFFFFF&}{\c&HCCFFFF&}き{\c&HCCFFFF&}て…
+Dialogue: 0,0:18:28.20,0:18:29.69,Default,,0,0,0,,{\c&HCCFFCC&}Evict{\c&HCCFFCC&} {\c&HFFFFCC&}you{\c&HFFFFCC&} {\c&HFFCCCC&}?{\c&HFFCCCC&}
+Dialogue: 0,0:18:28.26,0:18:29.66,Default-ja,,0,0,0,,{\c&HCCFFCC&}（{\c&HCCFFCC&}{\c&HFFFFCC&}圭一{\c&HFFFFCC&}{\c&HFFCCCC&}）{\c&HFFCCCC&}一方的に？
+Dialogue: 0,0:18:30.29,0:18:34.10,Default-ja,,0,0,0,,{\c&HFFCCFF&}だから{\c&HFFCCFF&}{\c&HCCE5FF&}闘っ{\c&HCCE5FF&}{\c&HFFD8B1&}た{\c&HFFD8B1&}{\c&HCCE0FF&}ん{\c&HCCE0FF&}{\c&HFFFFE0&}だ{\c&HFFFFE0&}{\c&HFFF0F5&}よ{\c&HFFF0F5&}{\c&HFFE4E1&}村{\c&HFFE4E1&}{\c&HFAFAD2&}の{\c&HFAFAD2&}{\c&HFFFACD&}みんな{\c&HFFFACD&}{\c&HFFEFD5&}で{\c&HFFEFD5&}
+Dialogue: 0,0:18:30.30,0:18:34.33,Default,,0,0,0,,{\c&HFFCCFF&}That's{\c&HFFCCFF&} {\c&HCCE5FF&}why{\c&HCCE5FF&} {\c&HFFD8B1&}we{\c&HFFD8B1&} {\c&HCCE0FF&}fought{\c&HCCE0FF&} {\c&HFFFFE0&}.\{\c&HFFFFE0&} {\c&HFFF0F5&}NEveryone{\c&HFFF0F5&} {\c&HFFE4E1&}in{\c&HFFE4E1&} {\c&HFAFAD2&}the{\c&HFAFAD2&} {\c&HFFFACD&}village{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:18:34.43,0:18:38.70,Default-ja,,0,0,0,,{\c&HFFFFF0&}闘わ{\c&HFFFFF0&}{\c&HFFF5EE&}なけれ{\c&HFFF5EE&}{\c&HFAEBD7&}ば{\c&HFAEBD7&}{\c&HFFFAFA&}今{\c&HFFFAFA&}{\c&HCCFFFF&}ごろ{\c&HCCFFFF&}{\c&HFFFFFF&}\{\c&HFFFFFF&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HCCFFCC&}村{\c&HCCFFCC&}{\c&HFFFFCC&}は{\c&HFFFFCC&}{\c&HFFCCCC&}ダム{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}{\c&HCCE5FF&}底{\c&HCCE5FF&}に沈んでいたんだ
+Dialogue: 0,0:18:34.44,0:18:38.67,Default,,0,0,0,,{\c&HFFFFF0&}If{\c&HFFFFF0&} {\c&HFFF5EE&}we{\c&HFFF5EE&} {\c&HFAEBD7&}hadn't{\c&HFAEBD7&} {\c&HFFFAFA&},{\c&HFFFAFA&} {\c&HCCFFFF&}this{\c&HCCFFFF&} {\c&HFFFFFF&}village{\c&HFFFFFF&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HCCFFCC&}Nwould've{\c&HCCFFCC&} {\c&HFFFFCC&}been{\c&HFFFFCC&} {\c&HFFCCCC&}underwater{\c&HFFCCCC&} {\c&HFFCCFF&}now{\c&HFFCCFF&} {\c&HCCE5FF&}.{\c&HCCE5FF&}
+Dialogue: 0,0:18:39.57,0:18:43.14,Default-ja,,0,0,0,,{\c&HFFD8B1&}（{\c&HFFD8B1&}{\c&HCCE0FF&}圭一{\c&HCCE0FF&}{\c&HFFFFE0&}）{\c&HFFFFE0&}{\c&HFFF0F5&}\{\c&HFFF0F5&}{\c&HFFE4E1&}N{\c&HFFE4E1&}{\c&HFAFAD2&}よく{\c&HFAFAD2&}{\c&HFFFACD&}勝て{\c&HFFFACD&}{\c&HFFEFD5&}た{\c&HFFEFD5&}{\c&HFFFFF0&}な{\c&HFFFFF0&}{\c&HFFF5EE&}　{\c&HFFF5EE&}{\c&HFAEBD7&}相手{\c&HFAEBD7&}は国だろう？
+Dialogue: 0,0:18:39.68,0:18:43.81,Default,,0,0,0,,{\c&HFFD8B1&}I'm{\c&HFFD8B1&} {\c&HCCE0FF&}impressed{\c&HCCE0FF&} {\c&HFFFFE0&}you{\c&HFFFFE0&} {\c&HFFF0F5&}won{\c&HFFF0F5&} {\c&HFFE4E1&}.\{\c&HFFE4E1&} {\c&HFAFAD2&}NIt{\c&HFAFAD2&} {\c&HFFFACD&}was{\c&HFFFACD&} {\c&HFFEFD5&}against{\c&HFFEFD5&} {\c&HFFFFF0&}the{\c&HFFFFF0&} {\c&HFFF5EE&}government{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:18:43.92,0:18:48.55,Default,,0,0,0,,{\c&HFFFAFA&}The{\c&HFFFAFA&} {\c&HCCFFFF&}village's{\c&HCCFFFF&} {\c&HFFFFFF&}leader{\c&HFFFFFF&} {\c&HCCFFFF&}and{\c&HCCFFFF&} {\c&HCCFFCC&}powerful{\c&HCCFFCC&} {\c&HFFFFCC&}\{\c&HFFFFCC&} {\c&HFFCCCC&}Npeople{\c&HFFCCCC&} {\c&HFFCCFF&}petitioned{\c&HFFCCFF&} {\c&HCCE5FF&}together{\c&HCCE5FF&} {\c&HFFD8B1&}.{\c&HFFD8B1&}
+Dialogue: 0,0:18:44.01,0:18:48.21,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}魅{\c&HCCFFFF&}{\c&HFFFFFF&}音{\c&HFFFFFF&}{\c&HCCFFFF&}）{\c&HCCFFFF&}{\c&HCCFFCC&}村長{\c&HCCFFCC&}{\c&HFFFFCC&}や{\c&HFFFFCC&}{\c&HFFCCCC&}村{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}{\c&HCCE5FF&}有力{\c&HCCE5FF&}{\c&HFFD8B1&}者{\c&HFFD8B1&}たちがね\N方々に陳情した
+Dialogue: 0,0:18:48.61,0:18:52.42,Default-ja,,0,0,0,,{\c&HCCE0FF&}東京{\c&HCCE0FF&}{\c&HFFFFE0&}に{\c&HFFFFE0&}{\c&HFFF0F5&}も{\c&HFFF0F5&}{\c&HFFE4E1&}行っ{\c&HFFE4E1&}{\c&HFAFAD2&}た{\c&HFAFAD2&}{\c&HFFFACD&}し{\c&HFFFACD&}{\c&HFFEFD5&}\{\c&HFFEFD5&}{\c&HFFFFF0&}N{\c&HFFFFF0&}{\c&HFFF5EE&}いろんな{\c&HFFF5EE&}{\c&HFAEBD7&}政治{\c&HFAEBD7&}{\c&HFFFAFA&}家{\c&HFFFAFA&}に根回しもした
+Dialogue: 0,0:18:48.66,0:18:53.09,Default,,0,0,0,,{\c&HCCE0FF&}They{\c&HCCE0FF&} {\c&HFFFFE0&}went{\c&HFFFFE0&} {\c&HFFF0F5&}to{\c&HFFF0F5&} {\c&HFFE4E1&}Tokyo{\c&HFFE4E1&} {\c&HFAFAD2&}and{\c&HFAFAD2&} {\c&HFFFACD&}\{\c&HFFFACD&} {\c&HFFEFD5&}Nnegotiated{\c&HFFEFD5&} {\c&HFFFFF0&}with{\c&HFFFFF0&} {\c&HFFF5EE&}the{\c&HFFF5EE&} {\c&HFAEBD7&}politicians{\c&HFAEBD7&} {\c&HFFFAFA&}.{\c&HFFFAFA&}
+Dialogue: 0,0:18:53.19,0:18:56.75,Default,,0,0,0,,{\c&HCCFFFF&}While{\c&HCCFFFF&} {\c&HFFFFFF&}doing{\c&HFFFFFF&} {\c&HCCFFFF&}all{\c&HCCFFFF&} {\c&HCCFFCC&}that{\c&HCCFFCC&} {\c&HFFFFCC&},\{\c&HFFFFCC&} {\c&HFFCCCC&}Nthe{\c&HFFCCCC&} {\c&HFFCCFF&}plans{\c&HFFCCFF&} {\c&HCCE5FF&}got{\c&HCCE5FF&} {\c&HFFD8B1&}withdrawn{\c&HFFD8B1&} {\c&HCCE0FF&}.{\c&HCCE0FF&}
+Dialogue: 0,0:18:53.25,0:18:56.22,Default-ja,,0,0,0,,{\c&HCCFFFF&}そう{\c&HCCFFFF&}{\c&HFFFFFF&}し{\c&HFFFFFF&}{\c&HCCFFFF&}て{\c&HCCFFFF&}{\c&HCCFFCC&}いる{\c&HCCFFCC&}{\c&HFFFFCC&}うち{\c&HFFFFCC&}{\c&HFFCCCC&}に{\c&HFFCCCC&}{\c&HFFCCFF&}\{\c&HFFCCFF&}{\c&HCCE5FF&}N{\c&HCCE5FF&}{\c&HFFD8B1&}計画{\c&HFFD8B1&}{\c&HCCE0FF&}は{\c&HCCE0FF&}撤回されたんだよ
+Dialogue: 0,0:18:56.86,0:18:59.33,Default,,0,0,0,,{\c&HFFFFE0&}It{\c&HFFFFE0&} {\c&HFFF0F5&}was{\c&HFFF0F5&} {\c&HFFE4E1&}our{\c&HFFE4E1&} {\c&HFAFAD2&}perfect{\c&HFAFAD2&} {\c&HFFFACD&}victory{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:18:56.99,0:19:00.09,Default-ja,,0,0,0,,{\c&HFFFFE0&}あたし{\c&HFFFFE0&}{\c&HFFF0F5&}たち{\c&HFFF0F5&}{\c&HFFE4E1&}の{\c&HFFE4E1&}{\c&HFAFAD2&}完全{\c&HFAFAD2&}{\c&HFFFACD&}勝利{\c&HFFFACD&}{\c&HFFEFD5&}だっ{\c&HFFEFD5&}た\Nハハハハッ…
+Dialogue: 0,0:19:01.19,0:19:05.60,Default-ja,,0,0,0,,{\c&HFFFFF0&}ふ{\c&HFFFFF0&}{\c&HFFF5EE&}～{\c&HFFF5EE&}{\c&HFAEBD7&}ん{\c&HFAEBD7&}{\c&HFFFAFA&}…{\c&HFFFAFA&}{\c&HCCFFFF&}暴力{\c&HCCFFFF&}{\c&HFFFFFF&}沙汰{\c&HFFFFFF&}{\c&HCCFFFF&}とか{\c&HCCFFFF&}{\c&HCCFFCC&}に{\c&HCCFFCC&}{\c&HFFFFCC&}は{\c&HFFFFCC&}{\c&HFFCCCC&}\{\c&HFFCCCC&}Nならなかったのか？
+Dialogue: 0,0:19:02.74,0:19:06.04,Default,,0,0,0,,{\c&HFFFFF0&}Were{\c&HFFFFF0&} {\c&HFFF5EE&}there{\c&HFFF5EE&} {\c&HFAEBD7&}any{\c&HFAEBD7&} {\c&HFFFAFA&}violent{\c&HFFFAFA&} {\c&HCCFFFF&}\{\c&HCCFFFF&} {\c&HFFFFFF&}Ncrimes{\c&HFFFFFF&} {\c&HCCFFFF&}because{\c&HCCFFFF&} {\c&HCCFFCC&}of{\c&HCCFFCC&} {\c&HFFFFCC&}it{\c&HFFFFCC&} {\c&HFFCCCC&}?{\c&HFFCCCC&}
+Dialogue: 0,0:19:06.14,0:19:09.01,Default,,0,0,0,,{\c&HFFCCFF&}Like{\c&HFFCCFF&} {\c&HCCE5FF&}assault{\c&HCCE5FF&} {\c&HFFD8B1&}or{\c&HFFD8B1&} {\c&HCCE0FF&}murder{\c&HCCE0FF&} ...
+Dialogue: 0,0:19:06.16,0:19:07.36,Default-ja,,0,0,0,,{\c&HFFCCFF&}傷害{\c&HFFCCFF&}{\c&HCCE5FF&}事件{\c&HCCE5FF&}{\c&HFFD8B1&}とか{\c&HFFD8B1&}{\c&HCCE0FF&}…{\c&HCCE0FF&}
 Dialogue: 0,0:19:08.00,0:19:09.17,Default-ja,,0,0,0,,殺人…
-Dialogue: 0,0:19:11.67,0:19:12.54,Default-ja,,0,0,0,,なかった
-Dialogue: 0,0:19:11.75,0:19:13.04,Default,,0,0,0,,There weren't.
-Dialogue: 0,0:19:13.85,0:19:15.68,Default,,0,0,0,,I-I see.
-Dialogue: 0,0:19:15.74,0:19:17.44,Default-ja,,0,0,0,,じゃ また あしたね
-Dialogue: 0,0:19:15.78,0:19:17.65,Default,,0,0,0,,See you tomorrow.
-Dialogue: 0,0:19:17.71,0:19:21.68,Default-ja,,0,0,0,,圭ちゃん それ\N家に帰るまで消しちゃダメだからね
-Dialogue: 0,0:19:17.75,0:19:22.21,Default,,0,0,0,,Kei-chan, you'd better not\Nerase that until you get home.
-Dialogue: 0,0:19:21.78,0:19:25.35,Default-ja,,0,0,0,,わ… 分かってるよ 消さねえよ！
-Dialogue: 0,0:19:22.92,0:19:25.22,Default,,0,0,0,,I know! I won't erase it!
-Dialogue: 0,0:19:34.12,0:19:37.13,Default-ja,,0,0,0,,よいしょ！ よいしょ！
-Dialogue: 0,0:19:38.41,0:19:39.96,Default,,0,0,0,,Hey, Rena!
-Dialogue: 0,0:19:38.43,0:19:40.13,Default-ja,,0,0,0,,（圭一）よう レナ！\N（ﾚﾅ）ハッ…
-Dialogue: 0,0:19:40.36,0:19:42.80,Default-ja,,0,0,0,,あっ！\N（圭一）精が出ますな
-Dialogue: 0,0:19:41.28,0:19:43.07,Default,,0,0,0,,Working hard, huh?
-Dialogue: 0,0:19:44.75,0:19:48.61,Default,,0,0,0,,Keiichi-kun!\NWhat are you doing here?
-Dialogue: 0,0:19:44.77,0:19:48.61,Default-ja,,0,0,0,,圭一君 どうしたの？ こんな所へ
-Dialogue: 0,0:19:48.71,0:19:52.21,Default-ja,,0,0,0,,事故発生の緊急通報を受け\N参上しました
-Dialogue: 0,0:19:48.72,0:19:52.15,Default,,0,0,0,,I got urgent info about\Nan accident and have come.
-Dialogue: 0,0:19:52.25,0:19:54.45,Default,,0,0,0,,Where is the injured person?
-Dialogue: 0,0:19:52.31,0:19:54.14,Default-ja,,0,0,0,,負傷者は どこでありますか？
-Dialogue: 0,0:19:54.24,0:19:56.55,Default-ja,,0,0,0,,えっ？ 事故って？
-Dialogue: 0,0:19:55.56,0:19:56.99,Default,,0,0,0,,Accident?
-Dialogue: 0,0:19:57.09,0:20:01.46,Default,,0,0,0,,I heard that a Kenta doll\Nis buried alive in the dumpster.
-Dialogue: 0,0:19:57.18,0:19:58.28,Default-ja,,0,0,0,,ケンタくん人形が―
+Dialogue: 0,0:19:11.67,0:19:12.54,Default-ja,,0,0,0,,{\c&HFFFFE0&}なかっ{\c&HFFFFE0&}{\c&HFFF0F5&}た{\c&HFFF0F5&}
+Dialogue: 0,0:19:11.75,0:19:13.04,Default,,0,0,0,,{\c&HFFFFE0&}There{\c&HFFFFE0&} {\c&HFFF0F5&}weren't{\c&HFFF0F5&} .
+Dialogue: 0,0:19:13.85,0:19:15.68,Default,,0,0,0,,{\c&HFFE4E1&}I{\c&HFFE4E1&} {\c&HFAFAD2&}-{\c&HFAFAD2&} {\c&HFFFACD&}I{\c&HFFFACD&} {\c&HFFEFD5&}see{\c&HFFEFD5&} .
+Dialogue: 0,0:19:15.74,0:19:17.44,Default-ja,,0,0,0,,{\c&HFFE4E1&}じゃ{\c&HFFE4E1&}{\c&HFAFAD2&}また{\c&HFAFAD2&}{\c&HFFFACD&}あした{\c&HFFFACD&}{\c&HFFEFD5&}ね{\c&HFFEFD5&}
+Dialogue: 0,0:19:15.78,0:19:17.65,Default,,0,0,0,,{\c&HFFFFF0&}See{\c&HFFFFF0&} {\c&HFFF5EE&}you{\c&HFFF5EE&} {\c&HFAEBD7&}tomorrow{\c&HFAEBD7&} {\c&HFFFAFA&}.{\c&HFFFAFA&}
+Dialogue: 0,0:19:17.71,0:19:21.68,Default-ja,,0,0,0,,{\c&HFFFFF0&}圭{\c&HFFFFF0&}{\c&HFFF5EE&}ちゃん{\c&HFFF5EE&}{\c&HFAEBD7&}それ{\c&HFAEBD7&}{\c&HFFFAFA&}\{\c&HFFFAFA&}N家に帰るまで消しちゃダメだからね
+Dialogue: 0,0:19:17.75,0:19:22.21,Default,,0,0,0,,{\c&HCCFFFF&}Kei{\c&HCCFFFF&} {\c&HFFFFFF&}-{\c&HFFFFFF&} {\c&HCCFFFF&}chan{\c&HCCFFFF&} {\c&HCCFFCC&},{\c&HCCFFCC&} {\c&HFFFFCC&}you'd{\c&HFFFFCC&} {\c&HFFCCCC&}better{\c&HFFCCCC&} {\c&HFFCCFF&}not{\c&HFFCCFF&} {\c&HCCE5FF&}\{\c&HCCE5FF&} {\c&HFFD8B1&}Nerase{\c&HFFD8B1&} that until you get home .
+Dialogue: 0,0:19:21.78,0:19:25.35,Default-ja,,0,0,0,,{\c&HCCFFFF&}わ{\c&HCCFFFF&}{\c&HFFFFFF&}…{\c&HFFFFFF&}{\c&HCCFFFF&}分かっ{\c&HCCFFFF&}{\c&HCCFFCC&}てる{\c&HCCFFCC&}{\c&HFFFFCC&}よ{\c&HFFFFCC&}{\c&HFFCCCC&}消さ{\c&HFFCCCC&}{\c&HFFCCFF&}ねえ{\c&HFFCCFF&}{\c&HCCE5FF&}よ{\c&HCCE5FF&}{\c&HFFD8B1&}！{\c&HFFD8B1&}
+Dialogue: 0,0:19:22.92,0:19:25.22,Default,,0,0,0,,{\c&HCCE0FF&}I{\c&HCCE0FF&} {\c&HFFFFE0&}know{\c&HFFFFE0&} {\c&HFFF0F5&}!{\c&HFFF0F5&} {\c&HFFE4E1&}I{\c&HFFE4E1&} won't erase it !
+Dialogue: 0,0:19:34.12,0:19:37.13,Default-ja,,0,0,0,,{\c&HCCE0FF&}よいしょ{\c&HCCE0FF&}{\c&HFFFFE0&}！{\c&HFFFFE0&}{\c&HFFF0F5&}よいしょ{\c&HFFF0F5&}{\c&HFFE4E1&}！{\c&HFFE4E1&}
+Dialogue: 0,0:19:38.41,0:19:39.96,Default,,0,0,0,,{\c&HFAFAD2&}Hey{\c&HFAFAD2&} {\c&HFFFACD&},{\c&HFFFACD&} {\c&HFFEFD5&}Rena{\c&HFFEFD5&} {\c&HFFFFF0&}!{\c&HFFFFF0&}
+Dialogue: 0,0:19:38.43,0:19:40.13,Default-ja,,0,0,0,,{\c&HFAFAD2&}（{\c&HFAFAD2&}{\c&HFFFACD&}圭一{\c&HFFFACD&}{\c&HFFEFD5&}）{\c&HFFEFD5&}{\c&HFFFFF0&}よう{\c&HFFFFF0&}レナ！\N（ﾚﾅ）ハッ…
+Dialogue: 0,0:19:40.36,0:19:42.80,Default-ja,,0,0,0,,{\c&HFFF5EE&}あっ{\c&HFFF5EE&}{\c&HFAEBD7&}！{\c&HFAEBD7&}{\c&HFFFAFA&}\{\c&HFFFAFA&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HFFFFFF&}（{\c&HFFFFFF&}圭一）精が出ますな
+Dialogue: 0,0:19:41.28,0:19:43.07,Default,,0,0,0,,{\c&HFFF5EE&}Working{\c&HFFF5EE&} {\c&HFAEBD7&}hard{\c&HFAEBD7&} {\c&HFFFAFA&},{\c&HFFFAFA&} {\c&HCCFFFF&}huh{\c&HCCFFFF&} {\c&HFFFFFF&}?{\c&HFFFFFF&}
+Dialogue: 0,0:19:44.75,0:19:48.61,Default,,0,0,0,,{\c&HCCFFFF&}Keiichi{\c&HCCFFFF&} {\c&HCCFFCC&}-{\c&HCCFFCC&} {\c&HFFFFCC&}kun{\c&HFFFFCC&} {\c&HFFCCCC&}!\{\c&HFFCCCC&} {\c&HFFCCFF&}NWhat{\c&HFFCCFF&} {\c&HCCE5FF&}are{\c&HCCE5FF&} {\c&HFFD8B1&}you{\c&HFFD8B1&} {\c&HCCE0FF&}doing{\c&HCCE0FF&} {\c&HFFFFE0&}here{\c&HFFFFE0&} {\c&HFFF0F5&}?{\c&HFFF0F5&}
+Dialogue: 0,0:19:44.77,0:19:48.61,Default-ja,,0,0,0,,{\c&HCCFFFF&}圭一{\c&HCCFFFF&}{\c&HCCFFCC&}君{\c&HCCFFCC&}{\c&HFFFFCC&}どう{\c&HFFFFCC&}{\c&HFFCCCC&}し{\c&HFFCCCC&}{\c&HFFCCFF&}た{\c&HFFCCFF&}{\c&HCCE5FF&}の{\c&HCCE5FF&}{\c&HFFD8B1&}？{\c&HFFD8B1&}{\c&HCCE0FF&}こんな{\c&HCCE0FF&}{\c&HFFFFE0&}所{\c&HFFFFE0&}{\c&HFFF0F5&}へ{\c&HFFF0F5&}
+Dialogue: 0,0:19:48.71,0:19:52.21,Default-ja,,0,0,0,,{\c&HFFE4E1&}事故{\c&HFFE4E1&}{\c&HFAFAD2&}発生{\c&HFAFAD2&}{\c&HFFFACD&}の{\c&HFFFACD&}{\c&HFFEFD5&}緊急{\c&HFFEFD5&}{\c&HFFFFF0&}通報{\c&HFFFFF0&}{\c&HFFF5EE&}を{\c&HFFF5EE&}{\c&HFAEBD7&}受け{\c&HFAEBD7&}{\c&HFFFAFA&}\{\c&HFFFAFA&}{\c&HCCFFFF&}N{\c&HCCFFFF&}{\c&HFFFFFF&}参上{\c&HFFFFFF&}{\c&HCCFFFF&}し{\c&HCCFFFF&}{\c&HCCFFCC&}まし{\c&HCCFFCC&}た
+Dialogue: 0,0:19:48.72,0:19:52.15,Default,,0,0,0,,{\c&HFFE4E1&}I{\c&HFFE4E1&} {\c&HFAFAD2&}got{\c&HFAFAD2&} {\c&HFFFACD&}urgent{\c&HFFFACD&} {\c&HFFEFD5&}info{\c&HFFEFD5&} {\c&HFFFFF0&}about{\c&HFFFFF0&} {\c&HFFF5EE&}\{\c&HFFF5EE&} {\c&HFAEBD7&}Nan{\c&HFAEBD7&} {\c&HFFFAFA&}accident{\c&HFFFAFA&} {\c&HCCFFFF&}and{\c&HCCFFFF&} {\c&HFFFFFF&}have{\c&HFFFFFF&} {\c&HCCFFFF&}come{\c&HCCFFFF&} {\c&HCCFFCC&}.{\c&HCCFFCC&}
+Dialogue: 0,0:19:52.25,0:19:54.45,Default,,0,0,0,,{\c&HFFFFCC&}Where{\c&HFFFFCC&} {\c&HFFCCCC&}is{\c&HFFCCCC&} {\c&HFFCCFF&}the{\c&HFFCCFF&} {\c&HCCE5FF&}injured{\c&HCCE5FF&} {\c&HFFD8B1&}person{\c&HFFD8B1&} {\c&HCCE0FF&}?{\c&HCCE0FF&}
+Dialogue: 0,0:19:52.31,0:19:54.14,Default-ja,,0,0,0,,{\c&HFFFFCC&}負傷{\c&HFFFFCC&}{\c&HFFCCCC&}者{\c&HFFCCCC&}{\c&HFFCCFF&}は{\c&HFFCCFF&}{\c&HCCE5FF&}どこ{\c&HCCE5FF&}{\c&HFFD8B1&}で{\c&HFFD8B1&}{\c&HCCE0FF&}あり{\c&HCCE0FF&}ますか？
+Dialogue: 0,0:19:54.24,0:19:56.55,Default-ja,,0,0,0,,{\c&HFFFFE0&}えっ{\c&HFFFFE0&}{\c&HFFF0F5&}？{\c&HFFF0F5&}事故って？
+Dialogue: 0,0:19:55.56,0:19:56.99,Default,,0,0,0,,{\c&HFFFFE0&}Accident{\c&HFFFFE0&} {\c&HFFF0F5&}?{\c&HFFF0F5&}
+Dialogue: 0,0:19:57.09,0:20:01.46,Default,,0,0,0,,{\c&HFFE4E1&}I{\c&HFFE4E1&} {\c&HFAFAD2&}heard{\c&HFAFAD2&} {\c&HFFFACD&}that{\c&HFFFACD&} {\c&HFFEFD5&}a{\c&HFFEFD5&} {\c&HFFFFF0&}Kenta{\c&HFFFFF0&} doll \ Nis buried alive in the dumpster .
+Dialogue: 0,0:19:57.18,0:19:58.28,Default-ja,,0,0,0,,{\c&HFFE4E1&}ケンタ{\c&HFFE4E1&}{\c&HFAFAD2&}くん{\c&HFAFAD2&}{\c&HFFFACD&}人形{\c&HFFFACD&}{\c&HFFEFD5&}が{\c&HFFEFD5&}{\c&HFFFFF0&}―{\c&HFFFFF0&}
 Dialogue: 0,0:19:58.38,0:20:01.55,Default-ja,,0,0,0,,ゴミ山に生き埋めになっているとの\N通報でしたが…
-Dialogue: 0,0:20:03.05,0:20:06.82,Default-ja,,0,0,0,,な… なんだ びっくりした
-Dialogue: 0,0:20:03.10,0:20:05.39,Default,,0,0,0,,O-Oh, that.
+Dialogue: 0,0:20:03.05,0:20:06.82,Default-ja,,0,0,0,,{\c&HFFF5EE&}な{\c&HFFF5EE&}{\c&HFAEBD7&}…{\c&HFAEBD7&}{\c&HFFFAFA&}なん{\c&HFFFAFA&}{\c&HCCFFFF&}だ{\c&HCCFFFF&}{\c&HFFFFFF&}びっくり{\c&HFFFFFF&}{\c&HCCFFFF&}し{\c&HCCFFFF&}た
+Dialogue: 0,0:20:03.10,0:20:05.39,Default,,0,0,0,,{\c&HFFF5EE&}O{\c&HFFF5EE&} {\c&HFAEBD7&}-{\c&HFAEBD7&} {\c&HFFFAFA&}Oh{\c&HFFFAFA&} {\c&HCCFFFF&},{\c&HCCFFFF&} {\c&HFFFFFF&}that{\c&HFFFFFF&} {\c&HCCFFFF&}.{\c&HCCFFFF&}
 Dialogue: 0,0:20:05.50,0:20:07.30,Default,,0,0,0,,You surprised me.
-Dialogue: 0,0:20:07.40,0:20:10.30,Default,,0,0,0,,So where's the Kenta doll?
-Dialogue: 0,0:20:07.42,0:20:10.33,Default-ja,,0,0,0,,…で どこだよ？ ケンタくんは
-Dialogue: 0,0:20:10.40,0:20:13.31,Default,,0,0,0,,Oh, sorry! Here, here!
-Dialogue: 0,0:20:10.43,0:20:11.76,Default-ja,,0,0,0,,あっ ごめん
-Dialogue: 0,0:20:12.06,0:20:13.83,Default-ja,,0,0,0,,ここ ここ！ ほら…
-Dialogue: 0,0:20:13.41,0:20:17.07,Default,,0,0,0,,Here, can you see it\Nthrough this crack?
-Dialogue: 0,0:20:14.33,0:20:17.23,Default-ja,,0,0,0,,この隙間から… 見える？
-Dialogue: 0,0:20:17.64,0:20:20.58,Default,,0,0,0,,Gee, he's totally buried alive.
-Dialogue: 0,0:20:17.70,0:20:20.64,Default-ja,,0,0,0,,（圭一）\Nこりゃ ホントに生き埋めだな
-Dialogue: 0,0:20:20.95,0:20:24.68,Default,,0,0,0,,We might need an axe\Nor saw to get it out.
+Dialogue: 0,0:20:07.40,0:20:10.30,Default,,0,0,0,,{\c&HCCFFCC&}So{\c&HCCFFCC&} {\c&HFFFFCC&}where's{\c&HFFFFCC&} {\c&HFFCCCC&}the{\c&HFFCCCC&} {\c&HFFCCFF&}Kenta{\c&HFFCCFF&} {\c&HCCE5FF&}doll{\c&HCCE5FF&} {\c&HFFD8B1&}?{\c&HFFD8B1&}
+Dialogue: 0,0:20:07.42,0:20:10.33,Default-ja,,0,0,0,,{\c&HCCFFCC&}…{\c&HCCFFCC&}{\c&HFFFFCC&}で{\c&HFFFFCC&}{\c&HFFCCCC&}どこ{\c&HFFCCCC&}{\c&HFFCCFF&}だ{\c&HFFCCFF&}{\c&HCCE5FF&}よ{\c&HCCE5FF&}{\c&HFFD8B1&}？{\c&HFFD8B1&}ケンタくんは
+Dialogue: 0,0:20:10.40,0:20:13.31,Default,,0,0,0,,{\c&HCCE0FF&}Oh{\c&HCCE0FF&} {\c&HFFFFE0&},{\c&HFFFFE0&} sorry ! Here , here !
+Dialogue: 0,0:20:10.43,0:20:11.76,Default-ja,,0,0,0,,{\c&HCCE0FF&}あっ{\c&HCCE0FF&}{\c&HFFFFE0&}ごめん{\c&HFFFFE0&}
+Dialogue: 0,0:20:12.06,0:20:13.83,Default-ja,,0,0,0,,{\c&HFFF0F5&}ここ{\c&HFFF0F5&}{\c&HFFE4E1&}ここ{\c&HFFE4E1&}{\c&HFAFAD2&}！{\c&HFAFAD2&}{\c&HFFFACD&}ほら{\c&HFFFACD&}{\c&HFFEFD5&}…{\c&HFFEFD5&}
+Dialogue: 0,0:20:13.41,0:20:17.07,Default,,0,0,0,,{\c&HFFF0F5&}Here{\c&HFFF0F5&} {\c&HFFE4E1&},{\c&HFFE4E1&} {\c&HFAFAD2&}can{\c&HFAFAD2&} {\c&HFFFACD&}you{\c&HFFFACD&} {\c&HFFEFD5&}see{\c&HFFEFD5&} it \ Nthrough this crack ?
+Dialogue: 0,0:20:14.33,0:20:17.23,Default-ja,,0,0,0,,{\c&HFFFFF0&}この{\c&HFFFFF0&}{\c&HFFF5EE&}隙間{\c&HFFF5EE&}{\c&HFAEBD7&}から{\c&HFAEBD7&}{\c&HFFFAFA&}…{\c&HFFFAFA&}{\c&HCCFFFF&}見える{\c&HCCFFFF&}{\c&HFFFFFF&}？{\c&HFFFFFF&}
+Dialogue: 0,0:20:17.64,0:20:20.58,Default,,0,0,0,,{\c&HFFFFF0&}Gee{\c&HFFFFF0&} {\c&HFFF5EE&},{\c&HFFF5EE&} {\c&HFAEBD7&}he's{\c&HFAEBD7&} {\c&HFFFAFA&}totally{\c&HFFFAFA&} {\c&HCCFFFF&}buried{\c&HCCFFFF&} {\c&HFFFFFF&}alive{\c&HFFFFFF&} .
+Dialogue: 0,0:20:17.70,0:20:20.64,Default-ja,,0,0,0,,{\c&HCCFFFF&}（{\c&HCCFFFF&}{\c&HCCFFCC&}圭一{\c&HCCFFCC&}{\c&HFFFFCC&}）{\c&HFFFFCC&}{\c&HFFCCCC&}\{\c&HFFCCCC&}{\c&HFFCCFF&}N{\c&HFFCCFF&}{\c&HCCE5FF&}こりゃ{\c&HCCE5FF&}{\c&HFFD8B1&}ホント{\c&HFFD8B1&}{\c&HCCE0FF&}に{\c&HCCE0FF&}{\c&HFFFFE0&}生き埋め{\c&HFFFFE0&}{\c&HFFF0F5&}だ{\c&HFFF0F5&}{\c&HFFE4E1&}な{\c&HFFE4E1&}
+Dialogue: 0,0:20:20.95,0:20:24.68,Default,,0,0,0,,{\c&HCCFFFF&}We{\c&HCCFFFF&} {\c&HCCFFCC&}might{\c&HCCFFCC&} {\c&HFFFFCC&}need{\c&HFFFFCC&} {\c&HFFCCCC&}an{\c&HFFCCCC&} {\c&HFFCCFF&}axe{\c&HFFCCFF&} {\c&HCCE5FF&}\{\c&HCCE5FF&} {\c&HFFD8B1&}Nor{\c&HFFD8B1&} {\c&HCCE0FF&}saw{\c&HCCE0FF&} {\c&HFFFFE0&}to{\c&HFFFFE0&} {\c&HFFF0F5&}get{\c&HFFF0F5&} {\c&HFFE4E1&}it{\c&HFFE4E1&} out .
 Dialogue: 0,0:20:21.10,0:20:24.74,Default-ja,,0,0,0,,本気でやるなら オノとか\Nノコギリが要るかもしれねえな
-Dialogue: 0,0:20:25.14,0:20:28.68,Default-ja,,0,0,0,,あっ ちょっと待ってて ねっ？\N（圭一）えっ？
-Dialogue: 0,0:20:25.75,0:20:27.98,Default,,0,0,0,,Just hold on, okay?
-Dialogue: 0,0:20:29.72,0:20:31.09,Default,,0,0,0,,Hey!
-Dialogue: 0,0:20:29.78,0:20:30.78,Default-ja,,0,0,0,,（圭一）おい！
-Dialogue: 0,0:20:44.56,0:20:46.33,Default-ja,,0,0,0,,（富竹）イヤな事件だったね
-Dialogue: 0,0:20:44.57,0:20:46.77,Default,,0,0,0,,It was a horrible crime.
-Dialogue: 0,0:20:46.80,0:20:50.10,Default-ja,,0,0,0,,腕が１本\Nまだ見つかってないんだろう？
-Dialogue: 0,0:20:46.87,0:20:49.90,Default,,0,0,0,,They still haven't found\None of the arms, right?
-Dialogue: 0,0:20:51.45,0:20:52.61,Default,,0,0,0,,Hinamizawa worker lynch death
-Dialogue: 0,0:20:52.60,0:20:53.60,Default-ja,,0,0,0,,（圭一）あった…
-Dialogue: 0,0:20:52.61,0:20:54.14,Default,,0,0,0,,Hinamizawa worker lynch death\NThere it is!
-Dialogue: 0,0:20:54.67,0:20:57.41,Default-ja,,0,0,0,,“雛見沢ダムで悪夢の惨劇”
-Dialogue: 0,0:20:54.72,0:20:57.78,Default,,0,0,0,,Nightmare tragedy\Nat Hinamizawa Dam.
-Dialogue: 0,0:20:57.81,0:21:00.11,Default-ja,,0,0,0,,“リンチ”“バラバラ殺人”
+Dialogue: 0,0:20:25.14,0:20:28.68,Default-ja,,0,0,0,,{\c&HFAFAD2&}あっ{\c&HFAFAD2&}{\c&HFFFACD&}ちょっと{\c&HFFFACD&}{\c&HFFEFD5&}待っ{\c&HFFEFD5&}{\c&HFFFFF0&}て{\c&HFFFFF0&}{\c&HFFF5EE&}て{\c&HFFF5EE&}{\c&HFAEBD7&}ねっ{\c&HFAEBD7&}？\N（圭一）えっ？
+Dialogue: 0,0:20:25.75,0:20:27.98,Default,,0,0,0,,{\c&HFAFAD2&}Just{\c&HFAFAD2&} {\c&HFFFACD&}hold{\c&HFFFACD&} {\c&HFFEFD5&}on{\c&HFFEFD5&} {\c&HFFFFF0&},{\c&HFFFFF0&} {\c&HFFF5EE&}okay{\c&HFFF5EE&} {\c&HFAEBD7&}?{\c&HFAEBD7&}
+Dialogue: 0,0:20:29.72,0:20:31.09,Default,,0,0,0,,{\c&HFFFAFA&}Hey{\c&HFFFAFA&} {\c&HCCFFFF&}!{\c&HCCFFFF&}
+Dialogue: 0,0:20:29.78,0:20:30.78,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}圭一{\c&HCCFFFF&}）おい！
+Dialogue: 0,0:20:44.56,0:20:46.33,Default-ja,,0,0,0,,{\c&HFFFFFF&}（{\c&HFFFFFF&}{\c&HCCFFFF&}富竹{\c&HCCFFFF&}{\c&HCCFFCC&}）{\c&HCCFFCC&}{\c&HFFFFCC&}イヤ{\c&HFFFFCC&}{\c&HFFCCCC&}な{\c&HFFCCCC&}{\c&HFFCCFF&}事件{\c&HFFCCFF&}だったね
+Dialogue: 0,0:20:44.57,0:20:46.77,Default,,0,0,0,,{\c&HFFFFFF&}It{\c&HFFFFFF&} {\c&HCCFFFF&}was{\c&HCCFFFF&} {\c&HCCFFCC&}a{\c&HCCFFCC&} {\c&HFFFFCC&}horrible{\c&HFFFFCC&} {\c&HFFCCCC&}crime{\c&HFFCCCC&} {\c&HFFCCFF&}.{\c&HFFCCFF&}
+Dialogue: 0,0:20:46.80,0:20:50.10,Default-ja,,0,0,0,,{\c&HCCE5FF&}腕{\c&HCCE5FF&}{\c&HFFD8B1&}が{\c&HFFD8B1&}{\c&HCCE0FF&}１{\c&HCCE0FF&}{\c&HFFFFE0&}本{\c&HFFFFE0&}{\c&HFFF0F5&}\{\c&HFFF0F5&}{\c&HFFE4E1&}N{\c&HFFE4E1&}{\c&HFAFAD2&}まだ{\c&HFAFAD2&}{\c&HFFFACD&}見つかっ{\c&HFFFACD&}{\c&HFFEFD5&}て{\c&HFFEFD5&}{\c&HFFFFF0&}ない{\c&HFFFFF0&}{\c&HFFF5EE&}ん{\c&HFFF5EE&}{\c&HFAEBD7&}だろ{\c&HFAEBD7&}う？
+Dialogue: 0,0:20:46.87,0:20:49.90,Default,,0,0,0,,{\c&HCCE5FF&}They{\c&HCCE5FF&} {\c&HFFD8B1&}still{\c&HFFD8B1&} {\c&HCCE0FF&}haven't{\c&HCCE0FF&} {\c&HFFFFE0&}found{\c&HFFFFE0&} {\c&HFFF0F5&}\{\c&HFFF0F5&} {\c&HFFE4E1&}None{\c&HFFE4E1&} {\c&HFAFAD2&}of{\c&HFAFAD2&} {\c&HFFFACD&}the{\c&HFFFACD&} {\c&HFFEFD5&}arms{\c&HFFEFD5&} {\c&HFFFFF0&},{\c&HFFFFF0&} {\c&HFFF5EE&}right{\c&HFFF5EE&} {\c&HFAEBD7&}?{\c&HFAEBD7&}
+Dialogue: 0,0:20:51.45,0:20:52.61,Default,,0,0,0,,{\c&HFFFAFA&}Hinamizawa{\c&HFFFAFA&} {\c&HCCFFFF&}worker{\c&HCCFFFF&} {\c&HFFFFFF&}lynch{\c&HFFFFFF&} {\c&HCCFFFF&}death{\c&HCCFFFF&}
+Dialogue: 0,0:20:52.60,0:20:53.60,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}圭一{\c&HCCFFFF&}{\c&HFFFFFF&}）{\c&HFFFFFF&}{\c&HCCFFFF&}あっ{\c&HCCFFFF&}た…
+Dialogue: 0,0:20:52.61,0:20:54.14,Default,,0,0,0,,{\c&HCCFFCC&}Hinamizawa{\c&HCCFFCC&} {\c&HFFFFCC&}worker{\c&HFFFFCC&} {\c&HFFCCCC&}lynch{\c&HFFCCCC&} {\c&HFFCCFF&}death{\c&HFFCCFF&} {\c&HCCE5FF&}\{\c&HCCE5FF&} {\c&HFFD8B1&}NThere{\c&HFFD8B1&} {\c&HCCE0FF&}it{\c&HCCE0FF&} {\c&HFFFFE0&}is{\c&HFFFFE0&} {\c&HFFF0F5&}!{\c&HFFF0F5&}
+Dialogue: 0,0:20:54.67,0:20:57.41,Default-ja,,0,0,0,,{\c&HCCFFCC&}“{\c&HCCFFCC&}{\c&HFFFFCC&}雛{\c&HFFFFCC&}{\c&HFFCCCC&}見沢{\c&HFFCCCC&}{\c&HFFCCFF&}ダム{\c&HFFCCFF&}{\c&HCCE5FF&}で{\c&HCCE5FF&}{\c&HFFD8B1&}悪夢{\c&HFFD8B1&}{\c&HCCE0FF&}の{\c&HCCE0FF&}{\c&HFFFFE0&}惨劇{\c&HFFFFE0&}{\c&HFFF0F5&}”{\c&HFFF0F5&}
+Dialogue: 0,0:20:54.72,0:20:57.78,Default,,0,0,0,,{\c&HFFE4E1&}Nightmare{\c&HFFE4E1&} {\c&HFAFAD2&}tragedy{\c&HFAFAD2&} {\c&HFFFACD&}\{\c&HFFFACD&} {\c&HFFEFD5&}Nat{\c&HFFEFD5&} {\c&HFFFFF0&}Hinamizawa{\c&HFFFFF0&} {\c&HFFF5EE&}Dam{\c&HFFF5EE&} {\c&HFAEBD7&}.{\c&HFAEBD7&}
+Dialogue: 0,0:20:57.81,0:21:00.11,Default-ja,,0,0,0,,{\c&HFFE4E1&}“{\c&HFFE4E1&}{\c&HFAFAD2&}リンチ{\c&HFAFAD2&}{\c&HFFFACD&}”{\c&HFFFACD&}{\c&HFFEFD5&}“{\c&HFFEFD5&}{\c&HFFFFF0&}バラバラ{\c&HFFFFF0&}{\c&HFFF5EE&}殺人{\c&HFFF5EE&}{\c&HFAEBD7&}”{\c&HFAEBD7&}
 Dialogue: 0,0:20:57.88,0:21:00.08,Default,,0,0,0,,Lynched and hacked to pieces.
-Dialogue: 0,0:21:00.19,0:21:04.28,Default,,0,0,0,,They beat the victim with hatchets\Nand pickaxes in cold blood.
-Dialogue: 0,0:21:00.28,0:21:02.41,Default-ja,,0,0,0,,“犯人たちは\N被害者をナタやツルハシで―”
-Dialogue: 0,0:21:02.51,0:21:06.22,Default-ja,,0,0,0,,“めった打ちにして惨殺し\N更に オノで遺体を―”
-Dialogue: 0,0:21:04.39,0:21:08.05,Default,,0,0,0,,Further, they cut the corpse\Ninto six parts with an axe...
-Dialogue: 0,0:21:06.32,0:21:10.15,Default-ja,,0,0,0,,“頭部 両腕 両足 胴体の\N６つに分割”
-Dialogue: 0,0:21:08.16,0:21:10.65,Default,,0,0,0,,...the head, arms, legs, and torso.
-Dialogue: 0,0:21:10.72,0:21:13.46,Default-ja,,0,0,0,,“犯人のうち１人は\Nいまだ逃走中”
-Dialogue: 0,0:21:10.76,0:21:13.93,Default,,0,0,0,,One of the murderers\Nis still on the loose.
-Dialogue: 0,0:21:13.56,0:21:15.23,Default-ja,,0,0,0,,あっ！\N（ﾚﾅ）知らない
-Dialogue: 0,0:21:14.87,0:21:16.27,Default,,0,0,0,,I don't know.
-Dialogue: 0,0:21:16.53,0:21:17.39,Default-ja,,0,0,0,,なかった
-Dialogue: 0,0:21:16.54,0:21:17.83,Default,,0,0,0,,There weren't.
-Dialogue: 0,0:21:20.17,0:21:22.94,Default,,0,0,0,,There really was one...
-Dialogue: 0,0:21:20.26,0:21:22.90,Default-ja,,0,0,0,,やっぱり あったんだ…
-Dialogue: 0,0:21:25.41,0:21:31.15,Default,,0,0,0,,In retrospect, those noisy\Ncicadas at that moment...
-Dialogue: 0,0:21:25.47,0:21:29.21,Default-ja,,0,0,0,,（圭一）あのとき うるさいほどに\N鳴いていた ひぐらしは―
-Dialogue: 0,0:21:29.64,0:21:34.51,Default-ja,,0,0,0,,今にして思えば\Nこれから始まる全てのことを―
-Dialogue: 0,0:21:31.99,0:21:37.12,Default,,0,0,0,,...were probably trying to warn\Nme of all the events to come.
-Dialogue: 0,0:21:34.81,0:21:37.48,Default-ja,,0,0,0,,俺に\N教えようとしていたのかもしれない
-Dialogue: 0,0:21:38.49,0:21:41.83,Default,,0,0,0,,Of all the things that\Nwere about to happen.
-Dialogue: 0,0:21:38.55,0:21:41.62,Default-ja,,0,0,0,,これから起こる全てのことを…
-Dialogue: 0,0:22:04.22,0:22:09.95,Default,,0,0,0,,To get my happiness,\NI had done everything...
+Dialogue: 0,0:21:00.19,0:21:04.28,Default,,0,0,0,,{\c&HFFFAFA&}They{\c&HFFFAFA&} {\c&HCCFFFF&}beat{\c&HCCFFFF&} {\c&HFFFFFF&}the{\c&HFFFFFF&} {\c&HCCFFFF&}victim{\c&HCCFFFF&} {\c&HCCFFCC&}with{\c&HCCFFCC&} {\c&HFFFFCC&}hatchets{\c&HFFFFCC&} {\c&HFFCCCC&}\{\c&HFFCCCC&} {\c&HFFCCFF&}Nand{\c&HFFCCFF&} {\c&HCCE5FF&}pickaxes{\c&HCCE5FF&} {\c&HFFD8B1&}in{\c&HFFD8B1&} {\c&HCCE0FF&}cold{\c&HCCE0FF&} {\c&HFFFFE0&}blood{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:21:00.28,0:21:02.41,Default-ja,,0,0,0,,{\c&HFFFAFA&}“{\c&HFFFAFA&}{\c&HCCFFFF&}犯人{\c&HCCFFFF&}{\c&HFFFFFF&}たち{\c&HFFFFFF&}{\c&HCCFFFF&}は{\c&HCCFFFF&}{\c&HCCFFCC&}\{\c&HCCFFCC&}{\c&HFFFFCC&}N{\c&HFFFFCC&}{\c&HFFCCCC&}被害{\c&HFFCCCC&}{\c&HFFCCFF&}者{\c&HFFCCFF&}{\c&HCCE5FF&}を{\c&HCCE5FF&}{\c&HFFD8B1&}ナタ{\c&HFFD8B1&}{\c&HCCE0FF&}や{\c&HCCE0FF&}{\c&HFFFFE0&}ツル{\c&HFFFFE0&}{\c&HFFF0F5&}ハシ{\c&HFFF0F5&}で―”
+Dialogue: 0,0:21:02.51,0:21:06.22,Default-ja,,0,0,0,,{\c&HFFE4E1&}“{\c&HFFE4E1&}{\c&HFAFAD2&}めった{\c&HFAFAD2&}{\c&HFFFACD&}打ち{\c&HFFFACD&}{\c&HFFEFD5&}に{\c&HFFEFD5&}{\c&HFFFFF0&}し{\c&HFFFFF0&}{\c&HFFF5EE&}て{\c&HFFF5EE&}{\c&HFAEBD7&}惨殺{\c&HFAEBD7&}{\c&HFFFAFA&}し{\c&HFFFAFA&}{\c&HCCFFFF&}\{\c&HCCFFFF&}{\c&HFFFFFF&}N{\c&HFFFFFF&}{\c&HCCFFFF&}更に{\c&HCCFFFF&}{\c&HCCFFCC&}オノ{\c&HCCFFCC&}{\c&HFFFFCC&}で{\c&HFFFFCC&}{\c&HFFCCCC&}遺体{\c&HFFCCCC&}を―”
+Dialogue: 0,0:21:04.39,0:21:08.05,Default,,0,0,0,,{\c&HFFE4E1&}Further{\c&HFFE4E1&} {\c&HFAFAD2&},{\c&HFAFAD2&} {\c&HFFFACD&}they{\c&HFFFACD&} {\c&HFFEFD5&}cut{\c&HFFEFD5&} {\c&HFFFFF0&}the{\c&HFFFFF0&} {\c&HFFF5EE&}corpse{\c&HFFF5EE&} {\c&HFAEBD7&}\{\c&HFAEBD7&} {\c&HFFFAFA&}Ninto{\c&HFFFAFA&} {\c&HCCFFFF&}six{\c&HCCFFFF&} {\c&HFFFFFF&}parts{\c&HFFFFFF&} {\c&HCCFFFF&}with{\c&HCCFFFF&} {\c&HCCFFCC&}an{\c&HCCFFCC&} {\c&HFFFFCC&}axe{\c&HFFFFCC&} {\c&HFFCCCC&}...{\c&HFFCCCC&}
+Dialogue: 0,0:21:06.32,0:21:10.15,Default-ja,,0,0,0,,{\c&HFFCCFF&}“{\c&HFFCCFF&}{\c&HCCE5FF&}頭部{\c&HCCE5FF&}{\c&HFFD8B1&}両{\c&HFFD8B1&}{\c&HCCE0FF&}腕{\c&HCCE0FF&}{\c&HFFFFE0&}両足{\c&HFFFFE0&}{\c&HFFF0F5&}胴体{\c&HFFF0F5&}{\c&HFFE4E1&}の{\c&HFFE4E1&}{\c&HFAFAD2&}\{\c&HFAFAD2&}{\c&HFFFACD&}N{\c&HFFFACD&}{\c&HFFEFD5&}６つ{\c&HFFEFD5&}{\c&HFFFFF0&}に{\c&HFFFFF0&}分割”
+Dialogue: 0,0:21:08.16,0:21:10.65,Default,,0,0,0,,{\c&HFFCCFF&}...{\c&HFFCCFF&} {\c&HCCE5FF&}the{\c&HCCE5FF&} {\c&HFFD8B1&}head{\c&HFFD8B1&} {\c&HCCE0FF&},{\c&HCCE0FF&} {\c&HFFFFE0&}arms{\c&HFFFFE0&} {\c&HFFF0F5&},{\c&HFFF0F5&} {\c&HFFE4E1&}legs{\c&HFFE4E1&} {\c&HFAFAD2&},{\c&HFAFAD2&} {\c&HFFFACD&}and{\c&HFFFACD&} {\c&HFFEFD5&}torso{\c&HFFEFD5&} {\c&HFFFFF0&}.{\c&HFFFFF0&}
+Dialogue: 0,0:21:10.72,0:21:13.46,Default-ja,,0,0,0,,{\c&HFFF5EE&}“{\c&HFFF5EE&}{\c&HFAEBD7&}犯人{\c&HFAEBD7&}{\c&HFFFAFA&}の{\c&HFFFAFA&}{\c&HCCFFFF&}うち{\c&HCCFFFF&}{\c&HFFFFFF&}１{\c&HFFFFFF&}{\c&HCCFFFF&}人{\c&HCCFFFF&}{\c&HCCFFCC&}は{\c&HCCFFCC&}{\c&HFFFFCC&}\{\c&HFFFFCC&}{\c&HFFCCCC&}N{\c&HFFCCCC&}{\c&HFFCCFF&}いまだ{\c&HFFCCFF&}{\c&HCCE5FF&}逃走{\c&HCCE5FF&}中”
+Dialogue: 0,0:21:10.76,0:21:13.93,Default,,0,0,0,,{\c&HFFF5EE&}One{\c&HFFF5EE&} {\c&HFAEBD7&}of{\c&HFAEBD7&} {\c&HFFFAFA&}the{\c&HFFFAFA&} {\c&HCCFFFF&}murderers{\c&HCCFFFF&} {\c&HFFFFFF&}\{\c&HFFFFFF&} {\c&HCCFFFF&}Nis{\c&HCCFFFF&} {\c&HCCFFCC&}still{\c&HCCFFCC&} {\c&HFFFFCC&}on{\c&HFFFFCC&} {\c&HFFCCCC&}the{\c&HFFCCCC&} {\c&HFFCCFF&}loose{\c&HFFCCFF&} {\c&HCCE5FF&}.{\c&HCCE5FF&}
+Dialogue: 0,0:21:13.56,0:21:15.23,Default-ja,,0,0,0,,{\c&HFFD8B1&}あっ{\c&HFFD8B1&}{\c&HCCE0FF&}！{\c&HCCE0FF&}{\c&HFFFFE0&}\{\c&HFFFFE0&}{\c&HFFF0F5&}N{\c&HFFF0F5&}（ﾚﾅ）知らない
+Dialogue: 0,0:21:14.87,0:21:16.27,Default,,0,0,0,,{\c&HFFD8B1&}I{\c&HFFD8B1&} {\c&HCCE0FF&}don't{\c&HCCE0FF&} {\c&HFFFFE0&}know{\c&HFFFFE0&} {\c&HFFF0F5&}.{\c&HFFF0F5&}
+Dialogue: 0,0:21:16.53,0:21:17.39,Default-ja,,0,0,0,,{\c&HFFE4E1&}なかっ{\c&HFFE4E1&}{\c&HFAFAD2&}た{\c&HFAFAD2&}
+Dialogue: 0,0:21:16.54,0:21:17.83,Default,,0,0,0,,{\c&HFFE4E1&}There{\c&HFFE4E1&} {\c&HFAFAD2&}weren't{\c&HFAFAD2&} .
+Dialogue: 0,0:21:20.17,0:21:22.94,Default,,0,0,0,,{\c&HFFFACD&}There{\c&HFFFACD&} {\c&HFFEFD5&}really{\c&HFFEFD5&} {\c&HFFFFF0&}was{\c&HFFFFF0&} {\c&HFFF5EE&}one{\c&HFFF5EE&} {\c&HFAEBD7&}...{\c&HFAEBD7&}
+Dialogue: 0,0:21:20.26,0:21:22.90,Default-ja,,0,0,0,,{\c&HFFFACD&}やっぱり{\c&HFFFACD&}{\c&HFFEFD5&}あっ{\c&HFFEFD5&}{\c&HFFFFF0&}た{\c&HFFFFF0&}{\c&HFFF5EE&}ん{\c&HFFF5EE&}{\c&HFAEBD7&}だ{\c&HFAEBD7&}…
+Dialogue: 0,0:21:25.41,0:21:31.15,Default,,0,0,0,,{\c&HFFFAFA&}In{\c&HFFFAFA&} {\c&HCCFFFF&}retrospect{\c&HCCFFFF&} {\c&HFFFFFF&},{\c&HFFFFFF&} {\c&HCCFFFF&}those{\c&HCCFFFF&} {\c&HCCFFCC&}noisy{\c&HCCFFCC&} {\c&HFFFFCC&}\{\c&HFFFFCC&} {\c&HFFCCCC&}Ncicadas{\c&HFFCCCC&} {\c&HFFCCFF&}at{\c&HFFCCFF&} {\c&HCCE5FF&}that{\c&HCCE5FF&} {\c&HFFD8B1&}moment{\c&HFFD8B1&} {\c&HCCE0FF&}...{\c&HCCE0FF&}
+Dialogue: 0,0:21:25.47,0:21:29.21,Default-ja,,0,0,0,,{\c&HFFFAFA&}（{\c&HFFFAFA&}{\c&HCCFFFF&}圭一{\c&HCCFFFF&}{\c&HFFFFFF&}）{\c&HFFFFFF&}{\c&HCCFFFF&}あの{\c&HCCFFFF&}{\c&HCCFFCC&}とき{\c&HCCFFCC&}{\c&HFFFFCC&}うるさい{\c&HFFFFCC&}{\c&HFFCCCC&}ほど{\c&HFFCCCC&}{\c&HFFCCFF&}に{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}鳴い{\c&HCCE0FF&}ていたひぐらしは―
+Dialogue: 0,0:21:29.64,0:21:34.51,Default-ja,,0,0,0,,{\c&HFFFFE0&}今{\c&HFFFFE0&}{\c&HFFF0F5&}に{\c&HFFF0F5&}{\c&HFFE4E1&}し{\c&HFFE4E1&}{\c&HFAFAD2&}て{\c&HFAFAD2&}{\c&HFFFACD&}思え{\c&HFFFACD&}{\c&HFFEFD5&}ば{\c&HFFEFD5&}{\c&HFFFFF0&}\{\c&HFFFFF0&}{\c&HFFF5EE&}N{\c&HFFF5EE&}{\c&HFAEBD7&}これから{\c&HFAEBD7&}{\c&HFFFAFA&}始まる{\c&HFFFAFA&}{\c&HCCFFFF&}全て{\c&HCCFFFF&}{\c&HFFFFFF&}の{\c&HFFFFFF&}{\c&HCCFFFF&}こと{\c&HCCFFFF&}{\c&HCCFFCC&}を{\c&HCCFFCC&}{\c&HFFFFCC&}―{\c&HFFFFCC&}
+Dialogue: 0,0:21:31.99,0:21:37.12,Default,,0,0,0,,{\c&HFFFFE0&}...{\c&HFFFFE0&} {\c&HFFF0F5&}were{\c&HFFF0F5&} {\c&HFFE4E1&}probably{\c&HFFE4E1&} {\c&HFAFAD2&}trying{\c&HFAFAD2&} {\c&HFFFACD&}to{\c&HFFFACD&} {\c&HFFEFD5&}warn{\c&HFFEFD5&} {\c&HFFFFF0&}\{\c&HFFFFF0&} {\c&HFFF5EE&}Nme{\c&HFFF5EE&} {\c&HFAEBD7&}of{\c&HFAEBD7&} {\c&HFFFAFA&}all{\c&HFFFAFA&} {\c&HCCFFFF&}the{\c&HCCFFFF&} {\c&HFFFFFF&}events{\c&HFFFFFF&} {\c&HCCFFFF&}to{\c&HCCFFFF&} {\c&HCCFFCC&}come{\c&HCCFFCC&} {\c&HFFFFCC&}.{\c&HFFFFCC&}
+Dialogue: 0,0:21:34.81,0:21:37.48,Default-ja,,0,0,0,,{\c&HFFCCCC&}俺{\c&HFFCCCC&}{\c&HFFCCFF&}に{\c&HFFCCFF&}{\c&HCCE5FF&}\{\c&HCCE5FF&}{\c&HFFD8B1&}N{\c&HFFD8B1&}{\c&HCCE0FF&}教えよ{\c&HCCE0FF&}{\c&HFFFFE0&}う{\c&HFFFFE0&}{\c&HFFF0F5&}と{\c&HFFF0F5&}{\c&HFFE4E1&}し{\c&HFFE4E1&}{\c&HFAFAD2&}て{\c&HFAFAD2&}{\c&HFFFACD&}い{\c&HFFFACD&}{\c&HFFEFD5&}た{\c&HFFEFD5&}のかもしれない
+Dialogue: 0,0:21:38.49,0:21:41.83,Default,,0,0,0,,{\c&HFFCCCC&}Of{\c&HFFCCCC&} {\c&HFFCCFF&}all{\c&HFFCCFF&} {\c&HCCE5FF&}the{\c&HCCE5FF&} {\c&HFFD8B1&}things{\c&HFFD8B1&} {\c&HCCE0FF&}that{\c&HCCE0FF&} {\c&HFFFFE0&}\{\c&HFFFFE0&} {\c&HFFF0F5&}Nwere{\c&HFFF0F5&} {\c&HFFE4E1&}about{\c&HFFE4E1&} {\c&HFAFAD2&}to{\c&HFAFAD2&} {\c&HFFFACD&}happen{\c&HFFFACD&} {\c&HFFEFD5&}.{\c&HFFEFD5&}
+Dialogue: 0,0:21:38.55,0:21:41.62,Default-ja,,0,0,0,,{\c&HFFFFF0&}これから{\c&HFFFFF0&}{\c&HFFF5EE&}起こる{\c&HFFF5EE&}{\c&HFAEBD7&}全て{\c&HFAEBD7&}{\c&HFFFAFA&}の{\c&HFFFAFA&}{\c&HCCFFFF&}こと{\c&HCCFFFF&}{\c&HFFFFFF&}を{\c&HFFFFFF&}{\c&HCCFFFF&}…{\c&HCCFFFF&}
+Dialogue: 0,0:22:04.22,0:22:09.95,Default,,0,0,0,,{\c&HFFFFF0&}To{\c&HFFFFF0&} {\c&HFFF5EE&}get{\c&HFFF5EE&} {\c&HFAEBD7&}my{\c&HFAEBD7&} {\c&HFFFAFA&}happiness{\c&HFFFAFA&} {\c&HCCFFFF&},\{\c&HCCFFFF&} {\c&HFFFFFF&}NI{\c&HFFFFFF&} {\c&HCCFFFF&}had{\c&HCCFFFF&} done everything ...
 Dialogue: 0,0:22:11.29,0:22:17.06,Default,,0,0,0,,...but had done nothing\Nto be blamed and accused of.
 Dialogue: 0,0:22:18.37,0:22:24.17,Default,,0,0,0,,The sound of footsteps\Nbecame louder every day.
 Dialogue: 0,0:22:24.27,0:22:31.30,Default,,0,0,0,,Then I noticed the fact\Nthere was no time.
@@ -695,16 +695,16 @@ Dialogue: 0,0:22:53.63,0:23:00.80,Default,,0,0,0,,Or judge me to be guilty\Nof s
 Dialogue: 0,0:23:00.91,0:23:07.37,Default,,0,0,0,,Tell me why or why not?\NComplaining way too much.
 Dialogue: 0,0:23:07.75,0:23:14.85,Default,,0,0,0,,Maybe I overlooked\Nsomething fatal for me.
 Dialogue: 0,0:23:16.09,0:23:18.16,Default,,0,0,0,,Preview
-Dialogue: 0,0:23:18.16,0:23:20.59,Default,,0,0,0,,Preview\NCan you believe\Nin things you can see?
-Dialogue: 0,0:23:18.31,0:23:21.75,Default-ja,,0,0,0,,（ﾅﾚｰﾀｰ）\N信じられるの？ 目に見えること
+Dialogue: 0,0:23:18.16,0:23:20.59,Default,,0,0,0,,{\c&HCCFFCC&}Preview{\c&HCCFFCC&} {\c&HFFFFCC&}\{\c&HFFFFCC&} {\c&HFFCCCC&}NCan{\c&HFFCCCC&} {\c&HFFCCFF&}you{\c&HFFCCFF&} {\c&HCCE5FF&}believe{\c&HCCE5FF&} {\c&HFFD8B1&}\{\c&HFFD8B1&} {\c&HCCE0FF&}Nin{\c&HCCE0FF&} {\c&HFFFFE0&}things{\c&HFFFFE0&} {\c&HFFF0F5&}you{\c&HFFF0F5&} {\c&HFFE4E1&}can{\c&HFFE4E1&} {\c&HFAFAD2&}see{\c&HFAFAD2&} {\c&HFFFACD&}?{\c&HFFFACD&}
+Dialogue: 0,0:23:18.31,0:23:21.75,Default-ja,,0,0,0,,{\c&HCCFFCC&}（{\c&HCCFFCC&}{\c&HFFFFCC&}ﾅﾚｰﾀｰ{\c&HFFFFCC&}{\c&HFFCCCC&}）\{\c&HFFCCCC&}{\c&HFFCCFF&}N{\c&HFFCCFF&}{\c&HCCE5FF&}信じ{\c&HCCE5FF&}{\c&HFFD8B1&}られる{\c&HFFD8B1&}{\c&HCCE0FF&}の{\c&HCCE0FF&}{\c&HFFFFE0&}？{\c&HFFFFE0&}{\c&HFFF0F5&}目{\c&HFFF0F5&}{\c&HFFE4E1&}に{\c&HFFE4E1&}{\c&HFAFAD2&}見える{\c&HFAFAD2&}{\c&HFFFACD&}こと{\c&HFFFACD&}
 Dialogue: 0,0:23:20.59,0:23:21.82,Default,,0,0,0,,Can you believe\Nin things you can see?
-Dialogue: 0,0:23:22.13,0:23:25.43,Default,,0,0,0,,Can you believe in living?
-Dialogue: 0,0:23:22.29,0:23:25.52,Default-ja,,0,0,0,,信じられるの？ 息づくこと
-Dialogue: 0,0:23:25.89,0:23:29.43,Default-ja,,0,0,0,,信じられるの？ 私のこと
-Dialogue: 0,0:23:25.90,0:23:29.20,Default,,0,0,0,,Can you believe in me?
-Dialogue: 0,0:23:29.86,0:23:31.83,Default-ja,,0,0,0,,「ひぐらしのなく頃に」
-Dialogue: 0,0:23:29.90,0:23:31.84,Default,,0,0,0,,When They Cry.
-Dialogue: 0,0:23:31.94,0:23:35.74,Default,,0,0,0,,Spirited Away by the Demon\NChapter Two, The Secret\NSpirited Away by the Demon\NChapter Two, The Secret.
-Dialogue: 0,0:23:35.73,0:23:38.60,Default-ja,,0,0,0,,あなたは信じられますか？
+Dialogue: 0,0:23:22.13,0:23:25.43,Default,,0,0,0,,{\c&HFFEFD5&}Can{\c&HFFEFD5&} {\c&HFFFFF0&}you{\c&HFFFFF0&} {\c&HFFF5EE&}believe{\c&HFFF5EE&} {\c&HFAEBD7&}in{\c&HFAEBD7&} {\c&HFFFAFA&}living{\c&HFFFAFA&} {\c&HCCFFFF&}?{\c&HCCFFFF&}
+Dialogue: 0,0:23:22.29,0:23:25.52,Default-ja,,0,0,0,,{\c&HFFEFD5&}信じ{\c&HFFEFD5&}{\c&HFFFFF0&}られる{\c&HFFFFF0&}{\c&HFFF5EE&}の{\c&HFFF5EE&}{\c&HFAEBD7&}？{\c&HFAEBD7&}{\c&HFFFAFA&}息づく{\c&HFFFAFA&}{\c&HCCFFFF&}こと{\c&HCCFFFF&}
+Dialogue: 0,0:23:25.89,0:23:29.43,Default-ja,,0,0,0,,{\c&HFFFFFF&}信じ{\c&HFFFFFF&}{\c&HCCFFFF&}られる{\c&HCCFFFF&}{\c&HCCFFCC&}の{\c&HCCFFCC&}{\c&HFFFFCC&}？{\c&HFFFFCC&}{\c&HFFCCCC&}私{\c&HFFCCCC&}{\c&HFFCCFF&}の{\c&HFFCCFF&}こと
+Dialogue: 0,0:23:25.90,0:23:29.20,Default,,0,0,0,,{\c&HFFFFFF&}Can{\c&HFFFFFF&} {\c&HCCFFFF&}you{\c&HCCFFFF&} {\c&HCCFFCC&}believe{\c&HCCFFCC&} {\c&HFFFFCC&}in{\c&HFFFFCC&} {\c&HFFCCCC&}me{\c&HFFCCCC&} {\c&HFFCCFF&}?{\c&HFFCCFF&}
+Dialogue: 0,0:23:29.86,0:23:31.83,Default-ja,,0,0,0,,{\c&HCCE5FF&}「{\c&HCCE5FF&}{\c&HFFD8B1&}ひぐらし{\c&HFFD8B1&}{\c&HCCE0FF&}の{\c&HCCE0FF&}{\c&HFFFFE0&}なく{\c&HFFFFE0&}頃に」
+Dialogue: 0,0:23:29.90,0:23:31.84,Default,,0,0,0,,{\c&HCCE5FF&}When{\c&HCCE5FF&} {\c&HFFD8B1&}They{\c&HFFD8B1&} {\c&HCCE0FF&}Cry{\c&HCCE0FF&} {\c&HFFFFE0&}.{\c&HFFFFE0&}
+Dialogue: 0,0:23:31.94,0:23:35.74,Default,,0,0,0,,{\c&HFFF0F5&}Spirited{\c&HFFF0F5&} {\c&HFFE4E1&}Away{\c&HFFE4E1&} {\c&HFAFAD2&}by{\c&HFAFAD2&} {\c&HFFFACD&}the{\c&HFFFACD&} {\c&HFFEFD5&}Demon{\c&HFFEFD5&} {\c&HFFFFF0&}\{\c&HFFFFF0&} {\c&HFFF5EE&}NChapter{\c&HFFF5EE&} Two , The Secret \ NSpirited Away by the Demon \ NChapter Two , The Secret .
+Dialogue: 0,0:23:35.73,0:23:38.60,Default-ja,,0,0,0,,{\c&HFFF0F5&}あなた{\c&HFFF0F5&}{\c&HFFE4E1&}は{\c&HFFE4E1&}{\c&HFAFAD2&}信じ{\c&HFAFAD2&}{\c&HFFFACD&}られ{\c&HFFFACD&}{\c&HFFEFD5&}ます{\c&HFFEFD5&}{\c&HFFFFF0&}か{\c&HFFFFF0&}{\c&HFFF5EE&}？{\c&HFFF5EE&}
 Dialogue: 0,0:23:35.74,0:23:35.98,Default,,0,0,0,,Spirited Away by the Demon\NChapter Two, The Secret\NCan you believe it?
 Dialogue: 0,0:23:35.98,0:23:38.88,Default,,0,0,0,,Can you believe it?

--- a/Higurashi no Naku Koro ni/Season 01/TODO.md
+++ b/Higurashi no Naku Koro ni/Season 01/TODO.md
@@ -1,5 +1,5 @@
 # Files to process:
-- [ ] (Hi10)_Higurashi_no_Naku_Koro_ni_-_01_(DVD_480p)_(Exiled-Destiny).ja-en.ass
+- [x] (Hi10)_Higurashi_no_Naku_Koro_ni_-_01_(DVD_480p)_(Exiled-Destiny).ja-en.ass
 - [ ] (Hi10)_Higurashi_no_Naku_Koro_ni_-_02_(DVD_480p)_(Exiled-Destiny).ja-en.ass
 - [ ] (Hi10)_Higurashi_no_Naku_Koro_ni_-_03_(DVD_480p)_(Exiled-Destiny).ja-en.ass
 - [ ] (Hi10)_Higurashi_no_Naku_Koro_ni_-_04_(DVD_480p)_(Exiled-Destiny).ja-en.ass


### PR DESCRIPTION
## Summary
- undo block coloring and apply word-level color tags to episode 1 subtitles

## Testing
- `apt-get update`
- `apt-get install -y mecab mecab-ipadic-utf8`
- `pip install fugashi`

------
https://chatgpt.com/codex/tasks/task_e_686053e0bb148328b83c7837e2caa474